### PR TITLE
Improve `id-match`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ module.exports = {
     'id-length': ['error', {
       exceptions: ['_', 'e', 'i']
     }],
-    'id-match': ['error', '^_$|^[a-zA-Z][a-zA-Z0-9]*$|^[A-Z][_A-Z0-9]+[A-Z0-9]$', {
+    'id-match': ['error', '^_$|^[$_a-zA-Z]*[_a-zA-Z0-9]*[a-zA-Z0-9]*$|^[A-Z][_A-Z0-9]+[A-Z0-9]$', {
       onlyDeclarations: true,
       properties: true
     }],

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -51,9 +51,9 @@ noop(function* foo() {});
 noop({ * foo() {} });
 
 // `id-match`.
-let id_match;
+let id_mátch;
 
-noop(id_match);
+noop(id_mátch);
 
 // `indent`.
 noop({


### PR DESCRIPTION
We're overriding this rule on every project, because it limits our usage of lodash's `_` and of snake_case elements required by external dependencies.

So let's fix it here and get rid of the overrides everywhere else.