### PR TITLE
Add max-len rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,7 @@ module.exports = {
     'linebreak-style': 'error',
     'lines-around-comment': 'off',
     'max-depth': 'error',
+    'max-len': ['error', 120],
     'max-nested-callbacks': 'off',
     'max-params': ['error', 4],
     'mocha/no-exclusive-tests': 'error',

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -70,6 +70,9 @@ if(keywordSpacing) {
   keywordSpacing = false;
 }
 
+// `max-len`.
+noop({ bar: 'This is a bar.', bar2: 'This is a bar 2.', bar3: 'This is a bar 3.', bar4: 'This is a bar 4.', bar5: 'This is a bar 5.' });
+
 // `mocha/no-exclusive-tests`.
 describe.only('noExclusiveTests', () => {
   it('should not work');

--- a/test/index.js
+++ b/test/index.js
@@ -23,10 +23,13 @@ describe('eslint-config-uphold', () => {
   it('should generate violations for environment-specific rules', () => {
     const source = path.join(__dirname, 'fixtures', 'environment.js');
 
-    Array.from(new Set(linter.executeOnFiles([source]).results[0].messages.map(violation => violation.ruleId))).should.eql([
-      'linebreak-style',
-      'eol-last'
-    ]);
+    Array
+      .from(new Set(linter.executeOnFiles([source]).results[0].messages.map(violation => violation.ruleId)))
+      .should
+      .eql([
+        'linebreak-style',
+        'eol-last'
+      ]);
   });
 
   it('should generate violations for incorrect code', () => {
@@ -51,6 +54,7 @@ describe('eslint-config-uphold', () => {
       'indent',
       'key-spacing',
       'keyword-spacing',
+      'max-len',
       'mocha/no-exclusive-tests',
       'mocha/no-identical-title',
       'mocha/no-nested-tests',


### PR DESCRIPTION
### Rule
Add [max-len](https://eslint.org/docs/rules/max-len) rule to uphold's eslint configuration.
This will help keep track of all lengthy lines of code so they can be read more clearly. I suggest an length of `120`.

### Reason
The main reason for adding the rule is to decrease the number of code styling comments on a Pull Request. So we can focus on the important part of the review. The idea for this actually came up during the review of a Frontend PR.

*Note*: There is no `--fix` for this rule so if we decide to add it someone would need to update the code base manually. Hopefully there aren't too many of those.

What do you guys think? Feel free to add more reviewers, not really sure who I should add.