### PR TITLE
Add prettier and replace redundant rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,12 @@
   },
   "dependencies": {
     "babel-eslint": "^10.0.2",
+    "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-mocha": "^5.3.0",
+    "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-sort-imports-es6": "^0.0.3",
-    "eslint-plugin-sql-template": "^2.0.0"
+    "eslint-plugin-sql-template": "^2.0.0",
+    "prettier": "^1.18.2"
   },
   "devDependencies": {
     "@uphold/github-changelog-generator": "^0.7.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Export `uphold` shared configuration preset.
  */
@@ -11,52 +10,44 @@ module.exports = {
     mocha: true,
     node: true
   },
-  extends: ['eslint:recommended'],
+  extends: ['eslint:recommended', 'plugin:prettier/recommended'],
   parser: 'babel-eslint',
   plugins: ['mocha', 'sort-imports-es6', 'sql-template'],
   root: true,
   rules: {
     'accessor-pairs': 'error',
-    'array-bracket-spacing': 'error',
-    'arrow-parens': ['error', 'as-needed'],
-    'arrow-spacing': 'error',
     'block-scoped-var': 'error',
     'block-spacing': 'off',
-    'brace-style': ['error', '1tbs', {
-      allowSingleLine: true
-    }],
     camelcase: 'off',
-    'comma-dangle': 'error',
-    'comma-spacing': 'error',
-    'comma-style': 'error',
     complexity: 'off',
-    'computed-property-spacing': 'error',
     'consistent-return': 'off',
     'consistent-this': ['error', 'self'],
     curly: 'error',
     'default-case': 'error',
-    'dot-location': ['error', 'property'],
     'dot-notation': 'error',
-    'eol-last': 'error',
     eqeqeq: ['error', 'smart'],
     'func-names': 'off',
-    'func-style': ['error', 'declaration', {
-      allowArrowFunctions: true
-    }],
-    'generator-star-spacing': ['error', 'before'],
-    'id-length': ['error', {
-      exceptions: ['_', 'e', 'i']
-    }],
-    'id-match': ['error', '^_$|^[$_a-zA-Z]*[_a-zA-Z0-9]*[a-zA-Z0-9]*$|^[A-Z][_A-Z0-9]+[A-Z0-9]$', {
-      onlyDeclarations: true,
-      properties: true
-    }],
-    indent: ['error', 2, {
-      SwitchCase: 1
-    }],
-    'key-spacing': 'error',
-    'keyword-spacing': 'error',
-    'linebreak-style': 'error',
+    'func-style': [
+      'error',
+      'declaration',
+      {
+        allowArrowFunctions: true
+      }
+    ],
+    'id-length': [
+      'error',
+      {
+        exceptions: ['_', 'e', 'i']
+      }
+    ],
+    'id-match': [
+      'error',
+      '^_$|^[$_a-zA-Z]*[_a-zA-Z0-9]*[a-zA-Z0-9]*$|^[A-Z][_A-Z0-9]+[A-Z0-9]$',
+      {
+        onlyDeclarations: true,
+        properties: true
+      }
+    ],
     'lines-around-comment': 'off',
     'max-depth': 'error',
     'max-nested-callbacks': 'off',
@@ -66,7 +57,6 @@ module.exports = {
     'mocha/no-nested-tests': 'error',
     'mocha/no-sibling-hooks': 'error',
     'new-cap': 'error',
-    'new-parens': 'error',
     'newline-before-return': 'error',
     'no-alert': 'error',
     'no-array-constructor': 'error',
@@ -74,7 +64,6 @@ module.exports = {
     'no-caller': 'error',
     'no-catch-shadow': 'off',
     'no-cond-assign': ['error', 'always'],
-    'no-confusing-arrow': 'error',
     'no-div-regex': 'error',
     'no-duplicate-imports': 'error',
     'no-else-return': 'error',
@@ -84,8 +73,6 @@ module.exports = {
     'no-eval': 'error',
     'no-extend-native': 'error',
     'no-extra-bind': 'error',
-    'no-extra-parens': 'error',
-    'no-floating-decimal': 'error',
     'no-implied-eval': 'error',
     'no-inline-comments': 'error',
     'no-iterator': 'error',
@@ -95,11 +82,7 @@ module.exports = {
     'no-lonely-if': 'error',
     'no-loop-func': 'error',
     'no-mixed-requires': 'error',
-    'no-multi-spaces': 'error',
     'no-multi-str': 'error',
-    'no-multiple-empty-lines': ['error', {
-      max: 1
-    }],
     'no-native-reassign': 'error',
     'no-nested-ternary': 'error',
     'no-new': 'error',
@@ -119,14 +102,11 @@ module.exports = {
     'no-sequences': 'error',
     'no-shadow': 'off',
     'no-shadow-restricted-names': 'error',
-    'no-spaced-func': 'error',
     'no-sync': 'error',
     'no-throw-literal': 'error',
-    'no-trailing-spaces': 'error',
     'no-undef-init': 'error',
     'no-undefined': 'off',
     'no-underscore-dangle': 'error',
-    'no-unexpected-multiline': 'error',
     'no-unneeded-ternary': 'error',
     'no-unused-expressions': 'error',
     'no-use-before-define': 'error',
@@ -136,63 +116,63 @@ module.exports = {
     'no-void': 'error',
     'no-warning-comments': 'off',
     'no-with': 'error',
-    'object-curly-spacing': ['error', 'always'],
     'object-shorthand': 'error',
-    'one-var': ['error', 'never'],
-    'one-var-declaration-per-line': ['error', 'always'],
     'operator-assignment': 'error',
-    'operator-linebreak': ['error', 'none'],
-    'padded-blocks': ['error', 'never'],
-    'padding-line-between-statements': ['error',
+    'padding-line-between-statements': [
+      'error',
       { blankLine: 'always', next: '*', prev: ['const', 'let', 'var'] },
       { blankLine: 'any', next: ['const', 'let', 'var'], prev: ['const', 'let', 'var'] }
     ],
-    'prefer-arrow-callback': 'error',
     'prefer-const': 'error',
-    'prefer-destructuring': ['error', {
-      AssignmentExpression: {
-        array: false,
-        object: false
+    'prefer-destructuring': [
+      'error',
+      {
+        AssignmentExpression: {
+          array: false,
+          object: false
+        },
+        VariableDeclarator: {
+          array: true,
+          object: true
+        }
       },
-      VariableDeclarator: {
-        array: true,
-        object: true
+      {
+        enforceForRenamedProperties: false
       }
-    }, {
-      enforceForRenamedProperties: false
-    }],
+    ],
     'prefer-spread': 'error',
     'prefer-template': 'error',
-    'quote-props': ['error', 'as-needed'],
-    quotes: ['error', 'single', {
-      allowTemplateLiterals: true
-    }],
+    'prettier/prettier': [
+      'error',
+      {
+        printWidth: 120,
+        singleQuote: true
+      }
+    ],
     radix: 'error',
     'require-atomic-updates': 'off',
     'require-await': 'error',
     'require-yield': 'error',
-    semi: 'error',
-    'semi-spacing': 'error',
-    'sort-imports-es6/sort-imports-es6': ['error', {
-      ignoreCase: false,
-      ignoreMemberSort: false,
-      memberSyntaxSortOrder: ['none', 'all', 'multiple', 'single']
-    }],
-    'sort-keys': ['error', 'asc', {
-      natural: true
-    }],
-    'space-before-blocks': 'error',
-    'space-before-function-paren': ['error', { anonymous: 'never', named: 'never' }],
-    'space-in-parens': 'error',
-    'space-infix-ops': 'error',
-    'space-unary-ops': 'error',
+    'sort-imports-es6/sort-imports-es6': [
+      'error',
+      {
+        ignoreCase: false,
+        ignoreMemberSort: false,
+        memberSyntaxSortOrder: ['none', 'all', 'multiple', 'single']
+      }
+    ],
+    'sort-keys': [
+      'error',
+      'asc',
+      {
+        natural: true
+      }
+    ],
     'spaced-comment': 'error',
     'sql-template/no-unsafe-query': 'error',
     strict: 'off',
-    'template-curly-spacing': 'error',
     'valid-jsdoc': 'error',
     'vars-on-top': 'error',
-    'wrap-iife': ['error', 'inside'],
     yoda: 'error'
   }
 };

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -13,32 +13,12 @@ function noop() {
   // do nothing
 }
 
-// `array-bracket-spacing`, `comma-spacing` and `no-multi-spaces`.
-noop(['bar', 'foo']);
-
-// `arrow-parens`
-noop(() => 'bar');
-noop(foo => foo);
-noop((foo, bar) => [foo, bar]);
-
-// `brace-style`.
-try {
-  noop();
-} catch (e) {
-  noop();
-}
-
-noop(function *() { return yield noop(); });
-
-// `comma-dangle`, `comma-style`.
-noop({ bar: 'foo', foo: 'bar' });
-
 // `consistent-this`.
 const self = this;
 
 noop(self);
 
-// `curly`, `keyword-spacing`, `no-empty` and `space-before-blocks`.
+// `curly` and `no-empty``.
 let mixedRules = true;
 
 if (mixedRules) {
@@ -51,11 +31,6 @@ if (mixedRules) {
 const dotNotation = {};
 
 dotNotation.foo = 'bar';
-
-// `generator-star-spacing`
-noop(function *() {});
-noop(function *foo() {});
-noop({ *foo() {} });
 
 // `id-match`.
 let idmatch;
@@ -75,9 +50,6 @@ noop(ID_MATCH);
 noop(ID_M_ATCH);
 noop(__dirname);
 noop(`${__dirname}`);
-
-// `key-spacing`.
-noop({ foo: 'bar' });
 
 // `mocha/no-exclusive-tests`.
 describe('noExclusiveTests', () => {
@@ -102,7 +74,7 @@ function funcThatReturns(bar) {
 funcThatReturns('foo');
 
 // `no-class-assign`.
-class NoClassAssign { }
+class NoClassAssign {}
 
 noop(NoClassAssign);
 
@@ -146,14 +118,6 @@ const noMultiStr = `Line 1
 
 noop(noMultiStr);
 
-// `no-multiple-empty-lines`.
-const noMultipleEmptyLines = true;
-
-noop(noMultipleEmptyLines);
-
-// `no-spaced-func`.
-noop();
-
 // `no-this-before-super`.
 const NoThisBeforeSuper = require('no-this-before-super');
 
@@ -171,32 +135,6 @@ noop(Child);
 // TODO: do something.
 // FIXME: this is not a good idea.
 
-// `object-curly-spacing`.
-const objectCurlySpacing1 = { foo: 'bar' };
-const objectCurlySpacing2 = {};
-
-noop(objectCurlySpacing1);
-noop(objectCurlySpacing2);
-
-// `one-var`, `one-var-declaration-per-line`.
-const oneVar1 = 'foo';
-const oneVar2 = 'bar';
-
-noop(oneVar1);
-noop(oneVar2);
-
-// `operator-linebreak`.
-const operatorLineBreak = 1 + 2;
-
-noop(operatorLineBreak);
-
-// `padded-blocks`.
-const paddedBlocks = true;
-
-if (paddedBlocks) {
-  noop();
-}
-
 // `padding-line-between-statements`.
 const newLineAfterVar = 'foo';
 
@@ -212,23 +150,14 @@ bar = biz.bar;
 biz = baz[0];
 baz = bar;
 
-// `quote-props`.
-const quoteProps = {
-  0: 0,
-  foo: 0,
-  'foo-bar': 0,
-  null: 0,
-  true: 0
-};
+// `prettier/prettier`.
+const singleQuote = 'true';
 
-noop(quoteProps);
+noop(singleQuote);
 
-// `quotes`.
-const quotes1 = 'foo';
-const quotes2 = `foo`;
+const maximumLineLength = '120';
 
-noop(quotes1);
-noop(quotes2);
+noop(maximumLineLength);
 
 // `require-atomic-updates`.
 (async (foo = {}) => {
@@ -241,14 +170,6 @@ noop(quotes2);
 (async () => {
   await noop();
 })();
-
-// `semi`.
-noop();
-
-// `semi-spacing`.
-for (let semiSpacing = 0; semiSpacing < 10; ++semiSpacing) {
-  noop();
-}
 
 // `sort-imports`.
 import 'import-1';
@@ -274,25 +195,6 @@ const sortObjectProps = {
 
 noop(sortObjectProps);
 
-// `space-before-function-paren`.
-(function() {
-  noop();
-})();
-
-// `space-in-parens`.
-noop('foo');
-
-// `space-infix-ops`.
-const spaceInfixOps = 1 + 2;
-
-noop(spaceInfixOps);
-
-// `space-unary-ops`.
-let spaceUnaryOps1 = 1;
-const spaceUnaryOps2 = ++spaceUnaryOps1;
-
-noop(spaceUnaryOps2);
-
 // `spaced-comment`.
 // spaced comment.
 
@@ -305,16 +207,6 @@ const sql = 'sql-tag';
 
 db.query(sql`SELECT ${foo} FROM bar`);
 db.query(`SELECT foo FROM bar`);
-
-// `template-curly-spacing`.
-const templateCurlySpacing = 'foo';
-
-noop(`${templateCurlySpacing}`);
-
-// `wrap-iife`.
-(function() {
-  noop();
-})();
 
 // `yoda`.
 let yoda = true;

--- a/test/fixtures/environment.js
+++ b/test/fixtures/environment.js
@@ -1,5 +1,0 @@
-// Incorrect environment-specific (os or editor) settings.
-
-// `linebreak-style` - Windows line endings (CRLF).
-
-// `eol-last` - no newline at the end of the file.

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -3,32 +3,6 @@ function noop() {
   // do nothing
 }
 
-// `array-bracket-spacing`.
-noop([ 'bar', 'foo']);
-
-// `arrow-parens`
-noop((foo) => noop(foo));
-
-// `brace-style`.
-try {
-  noop();
-}
-catch (e) {
-  noop();
-}
-
-// `comma-dangle`.
-noop({ bar: 'foo', foo: 'bar', });
-
-// `comma-spacing`.
-noop(['bar','foo']);
-
-// `comma-style`.
-noop({
-  bar: 'foo'
-  , foo: 'bar'
-});
-
 // `consistent-this`.
 const consistentThis = this;
 
@@ -37,38 +11,17 @@ noop(consistentThis);
 // `curly`.
 let curly = true;
 
-if (curly)
-  curly = false;
+if (curly) curly = false;
 
 // `dot-notation`.
 const dotNotation = {};
 
 dotNotation['foo'] = 'bar';
 
-// `generator-star-spacing`
-noop(function* () {});
-noop(function* foo() {});
-noop({ * foo() {} });
-
 // `id-match`.
 let id_mátch;
 
 noop(id_mátch);
-
-// `indent`.
-noop({
-    bar: 'foo'
-});
-
-// `key-spacing`.
-noop({ foo:'bar' });
-
-// `keyword-spacing`.
-let keywordSpacing = true;
-
-if(keywordSpacing) {
-  keywordSpacing = false;
-}
 
 // `mocha/no-exclusive-tests`.
 describe.only('noExclusiveTests', () => {
@@ -108,7 +61,7 @@ function funcThatReturns(bar) {
 funcThatReturns('foo');
 
 // `no-class-assign`.
-class NoClassAssign { }
+class NoClassAssign {}
 
 NoClassAssign = 'foobar';
 
@@ -149,23 +102,11 @@ noLabels: {
   break noLabels;
 }
 
-// `no-multi-spaces`.
-noop(['foo',  'bar']);
-
 // `no-multi-str`.
 const noMultiStr = 'Line 1 \
   Line 2';
 
 noop(noMultiStr);
-
-// `no-multiple-empty-lines`.
-const noMultipleEmptyLines = true;
-
-
-noop(noMultipleEmptyLines);
-
-// `no-spaced-func`.
-noop ();
 
 // `no-this-before-super`.
 const NoThisBeforeSuper = require('no-this-before-super');
@@ -191,38 +132,6 @@ noop(new NoUnderscoreDangle());
 // `no-unused-vars`
 const foobar = '';
 
-// `object-curly-spacing`.
-const objectCurlySpacing = {foo: 'bar'};
-
-noop(objectCurlySpacing);
-
-// `one-var`.
-const oneVar1 = 'foo', oneVar2 = 'bar';
-
-noop(oneVar1);
-noop(oneVar2);
-
-// `one-var-declaration-per-line`.
-const oneVarDeclarationPerLine1 = 'foo'; const oneVarDeclarationPerLine2 = 'bar';
-
-noop(oneVarDeclarationPerLine1);
-noop(oneVarDeclarationPerLine2);
-
-// `operator-linebreak`.
-const operatorLineBreak = 1 +
-  2;
-
-noop(operatorLineBreak);
-
-// `padded-blocks`.
-const paddedBlocks = true;
-
-if (paddedBlocks) {
-
-  noop();
-
-}
-
 // `padding-line-between-statements`.
 const newLineAfterVar = 'foo';
 noop(newLineAfterVar);
@@ -234,32 +143,17 @@ const baz = biz[0];
 
 noop(biz, baz);
 
-// `quote-props`.
-const quoteProps = {
-  '0': 0,
-  'foo': 0,
-  'foo-bar': 0,
-  'null': 0,
-  'true': 0
-};
+// `prettier/prettier`.
+const singleQuote = "true";
 
-noop(quoteProps);
+noop(singleQuote);
 
-// `quotes`.
-const quotes = "foo";
+const maximumLineLength = 'prettier dictates that lines of code must not exceed a length limit of 120 characters maximum';
 
-noop(quotes);
+noop(maximumLineLength);
 
 // `require-await`.
 (async () => {})();
-
-// `semi`.
-noop()
-
-// `semi-spacing`.
-for (let semiSpacing = 0;semiSpacing < 10;++semiSpacing) {
-  noop();
-}
 
 // `sort-imports`.
 import import1 from 'import-1';
@@ -277,34 +171,6 @@ const sortObjectProps = {
 
 noop(sortObjectProps);
 
-// `space-before-blocks`.
-let spaceBeforeBlocks = true;
-
-if (spaceBeforeBlocks){
-  spaceBeforeBlocks = false;
-} else {
-  spaceBeforeBlocks = true;
-}
-
-// `space-before-function-paren`.
-(function () {
-  noop();
-})();
-
-// `space-in-parens`.
-noop( 'foo' );
-
-// `space-infix-ops`.
-const spaceInfixOps = 1+2;
-
-noop(spaceInfixOps);
-
-// `space-unary-ops`.
-let spaceUnaryOps1 = 1;
-const spaceUnaryOps2 = ++ spaceUnaryOps1;
-
-noop(spaceUnaryOps2);
-
 // `spaced-comment`.
 //Comment missing space.
 
@@ -315,16 +181,6 @@ const db = {
 const foo = 'foo';
 
 db.query(`SELECT ${foo} FROM bar`);
-
-// `template-curly-spacing`.
-const templateCurlySpacing = 'foo';
-
-noop(`${ templateCurlySpacing }`);
-
-// `wrap-iife`.
-(function() {
-  noop();
-}());
 
 // `yoda`.
 let yoda = true;

--- a/test/index.js
+++ b/test/index.js
@@ -20,37 +20,14 @@ describe('eslint-config-uphold', () => {
     linter.executeOnFiles([source]).results[0].messages.should.be.empty();
   });
 
-  it('should generate violations for environment-specific rules', () => {
-    const source = path.join(__dirname, 'fixtures', 'environment.js');
-
-    Array.from(new Set(linter.executeOnFiles([source]).results[0].messages.map(violation => violation.ruleId))).should.eql([
-      'linebreak-style',
-      'eol-last'
-    ]);
-  });
-
   it('should generate violations for incorrect code', () => {
     const source = path.join(__dirname, 'fixtures', 'incorrect.js');
 
     Array.from(linter.executeOnFiles([source]).results[0].messages.map(violation => violation.ruleId)).should.eql([
-      'array-bracket-spacing',
-      'arrow-parens',
-      'brace-style',
-      'comma-dangle',
-      'comma-spacing',
-      'comma-style',
       'consistent-this',
       'curly',
       'dot-notation',
-      'generator-star-spacing',
-      'generator-star-spacing',
-      'generator-star-spacing',
-      'generator-star-spacing',
-      'generator-star-spacing',
       'id-match',
-      'indent',
-      'key-spacing',
-      'keyword-spacing',
       'mocha/no-exclusive-tests',
       'mocha/no-identical-title',
       'mocha/no-nested-tests',
@@ -65,44 +42,19 @@ describe('eslint-config-uphold', () => {
       'no-empty',
       'no-labels',
       'no-labels',
-      'no-multi-spaces',
       'no-multi-str',
-      'no-multiple-empty-lines',
-      'no-spaced-func',
       'no-this-before-super',
       'no-underscore-dangle',
       'no-unused-vars',
-      'object-curly-spacing',
-      'object-curly-spacing',
-      'one-var',
-      'one-var-declaration-per-line',
-      'operator-linebreak',
-      'padded-blocks',
-      'padded-blocks',
       'padding-line-between-statements',
       'prefer-destructuring',
       'prefer-destructuring',
-      'quote-props',
-      'quote-props',
-      'quote-props',
-      'quote-props',
-      'quotes',
-      'semi',
-      'semi-spacing',
-      'semi-spacing',
+      'prettier/prettier',
+      'prettier/prettier',
       'sort-imports-es6/sort-imports-es6',
       'sort-keys',
-      'space-before-blocks',
-      'space-before-function-paren',
-      'space-in-parens',
-      'space-in-parens',
-      'space-infix-ops',
-      'space-unary-ops',
       'spaced-comment',
       'sql-template/no-unsafe-query',
-      'template-curly-spacing',
-      'template-curly-spacing',
-      'wrap-iife',
       'yoda'
     ]);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -306,11 +306,23 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
+eslint-config-prettier@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.0.0.tgz#f429a53bde9fc7660e6353910fd996d6284d3c25"
+  dependencies:
+    get-stdin "^6.0.0"
+
 eslint-plugin-mocha@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-mocha/-/eslint-plugin-mocha-5.3.0.tgz#cf3eb18ae0e44e433aef7159637095a7cb19b15b"
   dependencies:
     ramda "^0.26.1"
+
+eslint-plugin-prettier@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.0.tgz#8695188f95daa93b0dc54b249347ca3b79c4686d"
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
 
 eslint-plugin-sort-imports-es6@^0.0.3:
   version "0.0.3"
@@ -433,6 +445,10 @@ fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
 
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
@@ -479,6 +495,10 @@ fs.realpath@^1.0.0:
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
 
 github@^6.1.0:
   version "6.1.0"
@@ -852,6 +872,16 @@ pre-commit@^1.2.2:
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  dependencies:
+    fast-diff "^1.1.2"
+
+prettier@^1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
 
 process-nextick-args@~2.0.0:
   version "2.0.0"


### PR DESCRIPTION
As previously discussed, we'd like to add prettier to our lint process in all our projects, to enforce a consistent code styling. This PR adds prettier and the usual configuration we were already using in some projects.

This PR also deletes any redundant eslint rule that is now also flagged by prettier. This should simplify this project and make linting faster.