### PR TITLE
Add peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,15 +31,19 @@
     "eslint-plugin-mocha": "^5.3.0",
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-sort-imports-es6": "^0.0.3",
-    "eslint-plugin-sql-template": "^2.0.0",
-    "prettier": "^1.18.2"
+    "eslint-plugin-sql-template": "^2.0.0"
   },
   "devDependencies": {
     "@uphold/github-changelog-generator": "^0.7.0",
     "eslint": "^6.0.1",
     "mocha": "^3.1.1",
     "pre-commit": "^1.2.2",
+    "prettier": "^1.18.2",
     "should": "^9.0.2"
+  },
+  "peerDependencies": {
+    "eslint": "^6.0.1",
+    "prettier": "^1.18.2"
   },
   "pre-commit": [
     "lint"


### PR DESCRIPTION
We're using the `eslint:recommended` preset, which changes on every eslint major version. So projects using only this config would get a different set of rules depending on their eslint version.

[Based](https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb/package.json) [on](https://github.com/prettier/eslint-config-prettier/blob/master/package.json) [other](https://github.com/standard/eslint-config-standard/blob/master/package.json) [projects](https://github.com/Shopify/eslint-plugin-shopify/blob/master/package.json), it seems that the convention is to declare in peer dependencies the eslint version we expect.

This PR also moves prettier from dependencies to dev dependencies and adds it to peer dependencies, as it's a similar situation as the one with eslint.

Other projects don't seem to have a convention for the required eslint plugins. Some keep them in dependencies, others have them in dev dependencies and peer dependencies. Since there is not a clear convention and since these are smaller scope packages, this PR still keeps them unchanged in dependencies.