### PR TITLE
Update eslint peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "should": "^9.0.2"
   },
   "peerDependencies": {
-    "eslint": "^6.0.1",
+    "eslint": "^6.5.1",
     "prettier": "^1.18.2"
   },
   "pre-commit": [


### PR DESCRIPTION
Mention a version where `eslint-utils` has its security vulnerability fixed.