### PR TITLE
Add `explicit-sinon-use-fake-timers` rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-mocha": "^5.3.0",
     "eslint-plugin-prettier": "^3.1.0",
+    "eslint-plugin-rulesdir": "^0.1.0",
     "eslint-plugin-sort-imports-es6": "^0.0.3",
     "eslint-plugin-sql-template": "^2.0.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,16 @@
 /**
+ * Module dependencies.
+ */
+
+const rulesDir = require('eslint-plugin-rulesdir');
+
+/**
+ * Configure the rulesdir plugin.
+ */
+
+rulesDir.RULES_DIR = `${__dirname}/rules`;
+
+/**
  * Export `uphold` shared configuration preset.
  */
 
@@ -12,7 +24,7 @@ module.exports = {
   },
   extends: ['eslint:recommended', 'plugin:prettier/recommended'],
   parser: 'babel-eslint',
-  plugins: ['mocha', 'sort-imports-es6', 'sql-template'],
+  plugins: ['mocha', 'rulesdir', 'sort-imports-es6', 'sql-template'],
   root: true,
   rules: {
     'accessor-pairs': 'error',
@@ -135,6 +147,7 @@ module.exports = {
     radix: 'error',
     'require-atomic-updates': 'off',
     'require-await': 'error',
+    'rulesdir/explicit-sinon-use-fake-timers': 'error',
     'sort-imports-es6/sort-imports-es6': [
       'error',
       {

--- a/src/rules/explicit-sinon-use-fake-timers.js
+++ b/src/rules/explicit-sinon-use-fake-timers.js
@@ -1,0 +1,50 @@
+'use strict';
+
+//------------------------------------------------------------------------------
+// Validates that `sinon.useFakeTimers()` is always called with an explicit `toFake` property.
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    messages: {
+      avoidName: "Calls to `sinon.useFakeTimers()` must provide a `toFake` configuration"
+    }
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (!node.callee || !node.callee.object || !node.callee.property) {
+          return;
+        }
+
+        if (node.callee.object.name === 'sinon' && node.callee.property.name === 'useFakeTimers') {
+          if (!node.arguments.length) {
+            context.report({
+              node,
+              message: 'Must pass an object with `toFake` configuration'
+            });
+          }
+
+          for (const argument of node.arguments) {
+            if (argument.type === 'ObjectExpression') {
+              if (!argument.properties.find(({ key: { name } }) => name === 'toFake')) {
+                context.report({
+                  node,
+                  message: 'Object must contain `toFake` configuration'
+                });
+              }
+
+              continue;
+            }
+
+            context.report({
+              node,
+              message: 'Not an object'
+            });
+          }
+        }
+      }
+    };
+
+  }
+};

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -165,6 +165,11 @@ noop(maximumLineLength);
   await noop();
 })();
 
+// `rulesdir/explicit-sinon-use-fake-timers`
+const sinon = {};
+
+sinon.useFakeTimers({ toFake: ['Date'] });
+
 // `sort-imports`.
 import 'import-1';
 import * as Import6 from 'import-2';

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -149,6 +149,11 @@ noop(maximumLineLength);
 // `require-await`.
 (async () => {})();
 
+// `rulesdir/explicit-sinon-use-fake-timers`
+const sinon = {};
+
+sinon.useFakeTimers();
+
 // `sort-imports`.
 import import1 from 'import-1';
 import { import2 } from 'import-2';

--- a/test/index.js
+++ b/test/index.js
@@ -22,8 +22,9 @@ describe('eslint-config-uphold', () => {
 
   it('should generate violations for incorrect code', () => {
     const source = path.join(__dirname, 'fixtures', 'incorrect.js');
+    const rules = linter.executeOnFiles([source]).results[0].messages.map(violation => violation.ruleId);
 
-    Array.from(linter.executeOnFiles([source]).results[0].messages.map(violation => violation.ruleId)).should.eql([
+    Array.from(rules).should.eql([
       'consistent-this',
       'curly',
       'dot-notation',
@@ -50,6 +51,7 @@ describe('eslint-config-uphold', () => {
       'prefer-destructuring',
       'prettier/prettier',
       'prettier/prettier',
+      'rulesdir/explicit-sinon-use-fake-timers',
       'sort-imports-es6/sort-imports-es6',
       'sort-keys',
       'spaced-comment',

--- a/yarn.lock
+++ b/yarn.lock
@@ -610,6 +610,11 @@ eslint-plugin-prettier@^3.1.0:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-rulesdir@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-rulesdir/-/eslint-plugin-rulesdir-0.1.0.tgz#ad144d7e98464fda82963eff3fab331aecb2bf08"
+  integrity sha1-rRRNfphGT9qClj7/P6szGuyyvwg=
+
 eslint-plugin-sort-imports-es6@^0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-sort-imports-es6/-/eslint-plugin-sort-imports-es6-0.0.3.tgz#959f391d459efbf971d3ebb696d79e1b567aeedc"


### PR DESCRIPTION
Adds a project-level rule that prevents using `sinon.useFakeTimers()` without passing in a `toFake` configuration explicitly.

This prevents users from inadvertedly mocking important functions such as `setTimeout`, `clearTimeout`, `setInterval`, `clearInterval`, `setImmediate`, `clearImmediate`, `process.hrtime`, `performance.now` (see [documentation](https://sinonjs.org/releases/latest/fake-timers/)).