### PR TITLE
Add `prefer-await-to-then` rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint-config-prettier": "^7.2.0",
     "eslint-plugin-mocha": "^5.3.0",
     "eslint-plugin-prettier": "^3.3.1",
+    "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-rulesdir": "^0.1.0",
     "eslint-plugin-sort-imports-requires": "^1.0.2",
     "eslint-plugin-sql-template": "^2.0.0"

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ module.exports = {
   parserOptions: {
     requireConfigFile: false
   },
-  plugins: ['mocha', 'rulesdir', 'sort-imports-requires', 'sql-template'],
+  plugins: ['mocha', 'promise', 'rulesdir', 'sort-imports-requires', 'sql-template'],
   root: true,
   rules: {
     'accessor-pairs': 'error',
@@ -133,6 +133,7 @@ module.exports = {
     'prefer-spread': 'error',
     'prefer-template': 'error',
     'prettier/prettier': ['error', { arrowParens: 'avoid', printWidth: 120, singleQuote: true, trailingComma: 'none' }],
+    'promise/prefer-await-to-then': 'error',
     radix: 'error',
     'require-atomic-updates': 'off',
     'require-await': 'error',

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -156,6 +156,11 @@ const maximumLineLength = '120';
 
 noop(maximumLineLength);
 
+// promise/prefer-await-to-then
+(async (foo = {}) => {
+  await foo;
+})();
+
 // `require-atomic-updates`.
 (async (foo = {}) => {
   await foo;

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -156,6 +156,11 @@ const maximumLineLength = 'prettier dictates that lines of code must not exceed 
 
 noop(maximumLineLength);
 
+// promise/prefer-await-to-then
+((foo = {}) => {
+  foo.then({});
+})();
+
 // `require-await`.
 (async () => {})();
 

--- a/test/index.js
+++ b/test/index.js
@@ -60,6 +60,7 @@ describe('eslint-config-uphold', () => {
       'prefer-destructuring',
       'prettier/prettier',
       'prettier/prettier',
+      'promise/prefer-await-to-then',
       'rulesdir/explicit-sinon-use-fake-timers',
       'sort-imports-requires/sort-imports',
       'sort-imports-requires/sort-requires',

--- a/yarn.lock
+++ b/yarn.lock
@@ -650,6 +650,11 @@ eslint-plugin-prettier@^3.3.1:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-promise@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-5.1.0.tgz#fb2188fb734e4557993733b41aa1a688f46c6f24"
+  integrity sha512-NGmI6BH5L12pl7ScQHbg7tvtk4wPxxj8yPHH47NvSmMtFneC077PSeY3huFj06ZWZvtbfxSPt3RuOQD5XcR4ng==
+
 eslint-plugin-rulesdir@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-rulesdir/-/eslint-plugin-rulesdir-0.1.0.tgz#ad144d7e98464fda82963eff3fab331aecb2bf08"


### PR DESCRIPTION
Adds the `eslint-plugin-promise` dependency in order to enforce a rule that async/await should be used in favor of promises (`.then()`, `.catch()`, etc.)
