### PR TITLE
Update `no-irregular-whitespace` rule

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+test/fixtures

--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,7 @@ module.exports = {
     'no-extra-bind': 'error',
     'no-implied-eval': 'error',
     'no-inline-comments': 'error',
+    'no-irregular-whitespace': ['error', { skipComments: false, skipStrings: false, skipTemplates: false }],
     'no-iterator': 'error',
     'no-labels': 'error',
     'no-lone-blocks': 'error',

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -82,6 +82,10 @@ class NoDupeClassMembers {
 
 noop(NoDupeClassMembers);
 
+// `no-irregular-whitespace`.
+// Comments should not have irregular spaces.
+noop('Strings cannot have irregular spaces', `String templates cannot have irregular spaces`);
+
 // `no-labels`.
 noLabels: {
   break noLabels;

--- a/test/index.js
+++ b/test/index.js
@@ -12,7 +12,7 @@ const path = require('path');
  */
 
 describe('eslint-config-uphold', () => {
-  const linter = new ESLint({ overrideConfigFile: path.join(__dirname, '..', 'src', 'index.js') });
+  const linter = new ESLint({ ignore: false, overrideConfigFile: path.join(__dirname, '..', 'src', 'index.js') });
 
   it('should not generate any violation for correct code', async () => {
     const source = path.join(__dirname, 'fixtures', 'correct.js');
@@ -41,6 +41,11 @@ describe('eslint-config-uphold', () => {
       'no-const-assign',
       'no-constant-condition',
       'no-dupe-class-members',
+      'no-irregular-whitespace',
+      'no-irregular-whitespace',
+      'prettier/prettier',
+      'no-irregular-whitespace',
+      'no-irregular-whitespace',
       'no-labels',
       'no-labels',
       'no-multi-str',


### PR DESCRIPTION
Updates the `no-irregular-whitespace` rule to also check for irregular whitespaces on comments, strings, and string templates.