### PR TITLE
Bump minimum node version to 12.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "lint"
   ],
   "engines": {
-    "node": ">=10.23.2"
+    "node": ">=12.22"
   },
   "options": {
     "mocha": "-t 10000 --require should test"


### PR DESCRIPTION
This PR bumps the node version to >= 12.22 since Node.js 10, 13, and 15 are no longer supported by Eslint v8.

https://eslint.org/docs/8.0.0/user-guide/migrating-to-8.0.0#-nodejs-10-13-and-15-are-no-longer-supported