### PR TITLE
Add no-console rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,14 @@ module.exports = {
     node: true
   },
   extends: ['eslint:recommended', 'plugin:prettier/recommended'],
+  overrides: [
+    {
+      files: ['**/bin/**', '**/scripts/**'],
+      rules: {
+        'no-console': 'off'
+      }
+    }
+  ],
   parser: '@babel/eslint-parser',
   parserOptions: {
     requireConfigFile: false
@@ -57,6 +65,7 @@ module.exports = {
     'no-bitwise': 'error',
     'no-caller': 'error',
     'no-cond-assign': ['error', 'always'],
+    'no-console': 'warn',
     'no-div-regex': 'error',
     'no-duplicate-imports': 'error',
     'no-else-return': 'error',

--- a/test/fixtures/bin/correct.js
+++ b/test/fixtures/bin/correct.js
@@ -1,0 +1,2 @@
+// `no-console`.
+console.log('foo');

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -6,6 +6,9 @@ function noop() {
 // `array-callback-return`.
 [1, 2].map(() => {});
 
+// `no-console`.
+console.log('foo');
+
 // `consistent-this`.
 const consistentThis = this;
 

--- a/test/fixtures/scripts/correct.js
+++ b/test/fixtures/scripts/correct.js
@@ -1,0 +1,2 @@
+// `no-console`.
+console.log('foo');

--- a/test/index.js
+++ b/test/index.js
@@ -28,6 +28,7 @@ describe('eslint-config-uphold', () => {
 
     Array.from(rules).should.eql([
       'array-callback-return',
+      'no-console',
       'consistent-this',
       'curly',
       'dot-notation',
@@ -67,5 +68,14 @@ describe('eslint-config-uphold', () => {
       'sql-template/no-unsafe-query',
       'yoda'
     ]);
+  });
+
+  it('should not generate any violation for correct code inside bin & scripts folders', async () => {
+    const source1 = path.join(__dirname, 'fixtures', 'bin', 'correct.js');
+    const source2 = path.join(__dirname, 'fixtures', 'scripts', 'correct.js');
+    const results = await linter.lintFiles([source1, source2]);
+
+    results[0].messages.should.be.empty();
+    results[1].messages.should.be.empty();
   });
 });


### PR DESCRIPTION
However, bin/ and scripts/ folder are excluded from it since we typically use console.log's there.