### PR TITLE
Add no-dupe-keys rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,7 @@ module.exports = {
     'no-cond-assign': ['error', 'always'],
     'no-console': 'warn',
     'no-div-regex': 'error',
+    'no-dupe-keys': 'error',
     'no-duplicate-imports': 'error',
     'no-else-return': 'error',
     'no-eq-null': 'error',

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -97,6 +97,11 @@ class NoDupeClassMembers {
 
 noop(NoDupeClassMembers);
 
+// `no-dupe-keys`.
+const noDupeKeys = { bar: 'foo', foo: 'bar' };
+
+noop(noDupeKeys);
+
 // `no-labels`.
 const noLabels = { label: true };
 

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -88,6 +88,11 @@ class NoDupeClassMembers {
 
 noop(NoDupeClassMembers);
 
+// `no-dupe-keys`.
+const noDupeKeys = { foo: 'bar', foo: 'biz' };
+
+noop(noDupeKeys);
+
 // `no-irregular-whitespace`.
 // Comments should not have irregular spaces.
 noop('Strings cannot have irregular spaces', `String templates cannot have irregular spaces`);

--- a/test/index.js
+++ b/test/index.js
@@ -43,6 +43,7 @@ describe('eslint-config-uphold', () => {
       'no-const-assign',
       'no-constant-condition',
       'no-dupe-class-members',
+      'no-dupe-keys',
       'no-irregular-whitespace',
       'no-irregular-whitespace',
       'prettier/prettier',


### PR DESCRIPTION
Do not allow duplicate keys in object literals.

See: https://eslint.org/docs/latest/rules/no-dupe-keys