### PR TITLE
Add sort-keys-fix plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-rulesdir": "^0.1.0",
     "eslint-plugin-sort-imports-requires": "^1.0.2",
+    "eslint-plugin-sort-keys-fix": "^1.1.2",
     "eslint-plugin-sql-template": "^2.0.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ module.exports = {
   parserOptions: {
     requireConfigFile: false
   },
-  plugins: ['mocha', 'promise', 'rulesdir', 'sort-imports-requires', 'sql-template'],
+  plugins: ['mocha', 'promise', 'rulesdir', 'sort-imports-requires', 'sort-keys-fix', 'sql-template'],
   root: true,
   rules: {
     'accessor-pairs': 'error',
@@ -154,7 +154,7 @@ module.exports = {
         useOldSingleMemberSyntax: true
       }
     ],
-    'sort-keys': ['error', 'asc', { natural: true }],
+    'sort-keys-fix/sort-keys-fix': ['error', 'asc', { natural: true }],
     'spaced-comment': 'error',
     'sql-template/no-unsafe-query': 'error',
     'valid-jsdoc': 'error',

--- a/src/rules/explicit-sinon-use-fake-timers.js
+++ b/src/rules/explicit-sinon-use-fake-timers.js
@@ -10,7 +10,7 @@ module.exports = {
       avoidName: 'Calls to `sinon.useFakeTimers()` must provide a `toFake` configuration'
     }
   },
-  // eslint-disable-next-line sort-keys
+  // eslint-disable-next-line sort-keys-fix/sort-keys-fix
   create(context) {
     return {
       CallExpression(node) {

--- a/test/index.js
+++ b/test/index.js
@@ -65,7 +65,7 @@ describe('eslint-config-uphold', () => {
       'rulesdir/explicit-sinon-use-fake-timers',
       'sort-imports-requires/sort-imports',
       'sort-imports-requires/sort-requires',
-      'sort-keys',
+      'sort-keys-fix/sort-keys-fix',
       'spaced-comment',
       'sql-template/no-unsafe-query',
       'yoda'

--- a/yarn.lock
+++ b/yarn.lock
@@ -301,10 +301,15 @@
     ini "^2.0.0"
     moment "^2.29.1"
 
-acorn-jsx@^5.3.2:
+acorn-jsx@^5.2.0, acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
+
+acorn@^7.1.1:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
+  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
 acorn@^8.7.1:
   version "8.7.1"
@@ -648,6 +653,16 @@ eslint-plugin-sort-imports-requires@^1.0.2:
     eslint-utils "^3.0.0"
     once "^1.4.0"
 
+eslint-plugin-sort-keys-fix@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-keys-fix/-/eslint-plugin-sort-keys-fix-1.1.2.tgz#00c8b5791612ec32162b8d7a0563e9c6eb27ec59"
+  integrity sha512-DNPHFGCA0/hZIsfODbeLZqaGY/+q3vgtshF85r+YWDNCQ2apd9PNs/zL6ttKm0nD1IFwvxyg3YOTI7FHl4unrw==
+  dependencies:
+    espree "^6.1.2"
+    esutils "^2.0.2"
+    natural-compare "^1.4.0"
+    requireindex "~1.2.0"
+
 eslint-plugin-sql-template@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-sql-template/-/eslint-plugin-sql-template-2.0.0.tgz#319937952f2ee1f830a3c6465f8eb2d3a7dcc7f7"
@@ -677,6 +692,11 @@ eslint-utils@^3.0.0:
   integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
   dependencies:
     eslint-visitor-keys "^2.0.0"
+
+eslint-visitor-keys@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
+  integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
 eslint-visitor-keys@^2.0.0, eslint-visitor-keys@^2.1.0:
   version "2.1.0"
@@ -728,6 +748,15 @@ eslint@~8.20.0:
     strip-json-comments "^3.1.0"
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
+
+espree@^6.1.2:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-6.2.1.tgz#77fc72e1fd744a2052c20f38a5b575832e82734a"
+  integrity sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==
+  dependencies:
+    acorn "^7.1.1"
+    acorn-jsx "^5.2.0"
+    eslint-visitor-keys "^1.1.0"
 
 espree@^9.3.2:
   version "9.3.2"
@@ -1393,6 +1422,11 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+
+requireindex@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
+  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
 
 resolve-from@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Description

- Add `eslint-plugin-sort-keys-fix` to auto sort keys in objects. 

## Why?
By default [eslint does not support autofix](https://github.com/eslint/eslint/issues/7714) for the built in `sort-keys` functionality. The justification here is that *some* code may rely on a particular order. This is true, but not common or the default behaviour in most code bases. At Uphold we enforce sort-keys as a warning and manually require this as part of PR's. This plugin provides autofix functionality while aligning with the `sort-keys` implementation. 

From my findings only a small section within Backend is order dependant. The common pattern between other repositories is migrations. We could potentially add an exception rule to exclude this from these directories, for now I've gone with the lightest touch which is to simply update any supressions.

## Rollout

To use this in a project, any supressions of the following form should be changed:

`/* eslint-disable sort-keys */` becomes `/* eslint-disable sort-keys-fix/sort-keys-fix */`

Alternatively if the issue is a geniue mistake - manually fix or apply `yarn lint --fix` / use your editor.

## Testing

I've tried and tested this in several repositories. See examples below. To test this in another project use the following hash or give me a nudge and I can trial out the change.

`git+ssh://git@github.com/uphold/eslint-config-uphold#1af3e33b4a5f046d71b7ffda244e690272719d07`

- https://github.com/uphold/backend/pull/10693
- https://github.com/uphold/wire-payments-gateway/pull/346
- GraphQL API, note this is running an old version of the config library so I have no build to demo, but having trialled locally this worked as expected. Some minor work will be required to ensure other rules are valid.