### PR TITLE
Fix `release-it`

### DIFF
--- a/.release-it.js
+++ b/.release-it.js
@@ -19,3 +19,4 @@ module.exports = {
   npm: {
     publish: true
   }
+};


### PR DESCRIPTION
Fixes `release-it.js`, which was missing a closing bracket.
It's on `.eslintignore`, so it didn't get linted.