### PR TITLE
Fix project dependency issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "should": "^13.2.3"
   },
   "peerDependencies": {
-    "eslint": ">=9.0.0",
+    "eslint": "~9.22.0",
     "prettier": ">=3.0.0"
   },
   "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,11 @@
     "eslint": ">=9.0.0",
     "prettier": ">=3.0.0"
   },
+  "peerDependenciesMeta": {
+    "prettier": {
+      "optional": true
+    }
+  },
   "pre-commit": [
     "lint"
   ],


### PR DESCRIPTION
- Makes prettier optional
- Locks the version of eslint to 9.22.0, allowing only patch bumps [see this](https://github.com/uphold/eslint-config-uphold#upgrading-eslint) for the reasoning behind this decision.