### PR TITLE
Remove `eslint-plugin-rulesdir` and update ESLint configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "eslint-plugin-n": "^17.16.2",
     "eslint-plugin-prettier": "^5.2.4",
     "eslint-plugin-promise": "^7.2.1",
-    "eslint-plugin-rulesdir": "^0.2.2",
     "eslint-plugin-sort-destructure-keys": "^2.0.0",
     "eslint-plugin-sort-imports-requires": "^2.0.0",
     "eslint-plugin-sort-keys-fix": "^1.1.2",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Module dependencies.
  *
@@ -12,20 +14,13 @@ const js = require('@eslint/js');
 const jsdoc = require('eslint-plugin-jsdoc');
 const mocha = require('eslint-plugin-mocha');
 const nodePlugin = require('eslint-plugin-n');
-const path = require('node:path');
 const promise = require('eslint-plugin-promise');
-const rulesDir = require('eslint-plugin-rulesdir');
+const rules = require('./rules');
 const sortDestructureKeys = require('eslint-plugin-sort-destructure-keys');
 const sortImportsRequires = require('eslint-plugin-sort-imports-requires');
 const sortKeysFix = require('eslint-plugin-sort-keys-fix');
 const sqlTemplate = require('eslint-plugin-sql-template');
 const stylistic = require('@stylistic/eslint-plugin-js');
-
-/**
- * Configure the `rulesDir` plugin.
- */
-
-rulesDir.RULES_DIR = path.join(__dirname, 'rules');
 
 /**
  * Language options.
@@ -63,12 +58,12 @@ const upholdBaseConfig = defineConfig([
       mocha,
       'node-plugin': nodePlugin,
       promise,
-      rulesdir: rulesDir,
       'sort-destructure-keys': sortDestructureKeys,
       'sort-imports-requires': sortImportsRequires,
       'sort-keys-fix': sortKeysFix,
       'sql-template': sqlTemplate,
-      stylistic
+      stylistic,
+      'uphold-plugin': { rules }
     },
     rules: {
       'accessor-pairs': 'error',
@@ -188,7 +183,6 @@ const upholdBaseConfig = defineConfig([
       radix: 'error',
       'require-atomic-updates': 'off',
       'require-await': 'error',
-      'rulesdir/explicit-sinon-use-fake-timers': 'error',
       'sort-destructure-keys/sort-destructure-keys': 'error',
       'sort-imports-requires/sort-imports': ['error', { unsafeAutofix: true, useOldSingleMemberSyntax: true }],
       'sort-imports-requires/sort-requires': [
@@ -221,6 +215,7 @@ const upholdBaseConfig = defineConfig([
         }
       ],
       'stylistic/spaced-comment': 'error',
+      'uphold-plugin/explicit-sinon-use-fake-timers': 'error',
       'vars-on-top': 'error',
       yoda: 'error'
     }

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+/**
+ * Export `rules`.
+ *
+ * @type {Record<string, import('eslint').Rule.RuleModule>}
+ */
+
+module.exports = {
+  'explicit-sinon-use-fake-timers': require('./explicit-sinon-use-fake-timers.js')
+};

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -167,7 +167,7 @@ noop(maximumLineLength);
   await noop();
 })();
 
-// `rulesdir/explicit-sinon-use-fake-timers`
+// `uphold-plugin/explicit-sinon-use-fake-timers`
 const sinon = {};
 
 sinon.useFakeTimers({ toFake: ['Date'] });

--- a/test/index.js
+++ b/test/index.js
@@ -63,7 +63,7 @@ describe('eslint-config-uphold', () => {
       'prettier/prettier',
       'prettier/prettier',
       'promise/prefer-await-to-then',
-      'rulesdir/explicit-sinon-use-fake-timers',
+      'uphold-plugin/explicit-sinon-use-fake-timers',
       'sort-destructure-keys/sort-destructure-keys',
       'sort-destructure-keys/sort-destructure-keys',
       'sort-destructure-keys/sort-destructure-keys',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1230,11 +1230,6 @@ eslint-plugin-promise@^7.2.1:
   dependencies:
     "@eslint-community/eslint-utils" "^4.4.0"
 
-eslint-plugin-rulesdir@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-rulesdir/-/eslint-plugin-rulesdir-0.2.2.tgz#84756ec39cd8503b1fe8af6a02a5da361e2bd076"
-  integrity sha512-qhBtmrWgehAIQeMDJ+Q+PnOz1DWUZMPeVrI0wE9NZtnpIMFUfh3aPKFYt2saeMSemZRrvUtjWfYwepsC8X+mjQ==
-
 eslint-plugin-sort-destructure-keys@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-sort-destructure-keys/-/eslint-plugin-sort-destructure-keys-2.0.0.tgz#23d26e3db4a8fb73fcd0dfceb2de4c517e6d603f"


### PR DESCRIPTION
## Description

- Eliminates the dependency on `eslint-plugin-rulesdir` by integrating the `explicit-sinon-use-fake-timers` rule as `uphold-plugin`.

Redo of #85 for CHANGELOG