### PR TITLE
Update Node.js minimum version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ that allow the [Prettier](https://prettier.io) pretty-printer to reformat the co
 npm install eslint eslint-config-uphold prettier --save-dev
 ```
 
+!! Node.js minimum versions are `v22.12.0` and `v20.19.0`, as `@stylistic/eslint-plugin-js` depends on the `require('esm')` module from `v4.0.0`.
+
 ## Usage
 
 Create an `eslint.config.js` file with the following content:

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "lint"
   ],
   "engines": {
-    "node": ">=20"
+    "node": "^20.19.0 || ^22.12.0"
   },
   "options": {
     "mocha": "-t 10000 --require should test"


### PR DESCRIPTION
## Description

- Sets the minimum Node.js versions to `v22.12.0` and `v20.19.0` in the README and `package.json`'s `engines`, as `@stylistic/eslint-plugin-js` depends on the `require('esm')` module from `v4.0.0`.

### Related

- [Node.js v22.12.0 CHANGELOG](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V22.md#2024-12-03-version-22120-jod-lts-ruyadorno) & [Node.js v22.12.0 Release Notes](https://nodejs.org/en/blog/release/v22.12.0#requireesm-is-now-enabled-by-default)
- [Node.js v20.19.0 CHANGELOG](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V20.md) & [Node.js v20.19.0 Release Notes](https://nodejs.org/en/blog/release/v20.19.0#requireesm-is-now-enabled-by-default)