### PR TITLE
Add support for `abbreviations` on `jsdoc/require-description-complete-sentence`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,12 @@ const upholdBaseConfig = defineConfig([
         }
       ],
       'jsdoc/no-defaults': 0,
-      'jsdoc/require-description-complete-sentence': 'error',
+      'jsdoc/require-description-complete-sentence': [
+        'error',
+        {
+          abbreviations: ['e.g.', 'i.e.', 'etc.']
+        }
+      ],
       'jsdoc/require-jsdoc': 0,
       'jsdoc/tag-lines': 0,
       'max-depth': 'error',


### PR DESCRIPTION
This PR aims to give support for `abbreviations` on `jsdoc/require-description-complete-sentence`.
This will allow the use lower case after words like, `e.g.`, `i.e.` or `etc.`