### PR TITLE
Add TypeScript support using `typescript-eslint`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,16 @@
   "files": [
     "src"
   ],
-  "publishConfig": {
-    "access": "public"
+  "exports": {
+    ".": {
+      "default": "./src/index.js"
+    },
+    "./javascript": {
+      "default": "./src/javascript.js"
+    },
+    "./typescript": {
+      "default": "./src/typescript.js"
+    }
   },
   "scripts": {
     "lint": "eslint",
@@ -53,14 +61,19 @@
     "@uphold/github-changelog-generator": "^4.0.2",
     "eslint": "^9.26.0",
     "prettier": "^3.5.3",
-    "release-it": "^19.0.2"
+    "release-it": "^19.0.2",
+    "typescript-eslint": "^8.32.0"
   },
   "peerDependencies": {
     "eslint": "~9.26.0",
-    "prettier": ">=3.0.0"
+    "prettier": ">=3.0.0",
+    "typescript-eslint": "~8.32.0"
   },
   "peerDependenciesMeta": {
     "prettier": {
+      "optional": true
+    },
+    "typescript-eslint": {
       "optional": true
     }
   },

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@eslint/js": "^9.26.0",
     "@stylistic/eslint-plugin": "^4.2.0",
     "eslint-config-prettier": "^10.1.5",
+    "eslint-plugin-jest": "^28.11.0",
     "eslint-plugin-jsdoc": "^50.6.14",
     "eslint-plugin-mocha": "^11.0.0",
     "eslint-plugin-n": "^17.18.0",

--- a/src/configs/common.js
+++ b/src/configs/common.js
@@ -1,0 +1,248 @@
+/**
+ * Module dependencies.
+ */
+
+import jsdocPlugin from 'eslint-plugin-jsdoc';
+import nodePlugin from 'eslint-plugin-n';
+import promisePlugin from 'eslint-plugin-promise';
+import rules from '../rules/index.js';
+import sortDestructureKeysPlugin from 'eslint-plugin-sort-destructure-keys';
+import sortImportsRequiresPlugin from 'eslint-plugin-sort-imports-requires';
+import sortKeysFixPlugin from 'eslint-plugin-sort-keys-fix';
+import sqlTemplatePlugin from 'eslint-plugin-sql-template';
+import stylisticPlugin from '@stylistic/eslint-plugin-js';
+
+export const eslintRules = {
+  'accessor-pairs': 'error',
+  'array-callback-return': 'error',
+  'block-scoped-var': 'error',
+  'consistent-this': ['error', 'self'],
+  curly: 'error',
+  'default-case': 'error',
+  'dot-notation': 'error',
+  eqeqeq: ['error', 'smart'],
+  'func-style': ['error', 'declaration', { allowArrowFunctions: true }],
+  'id-length': ['error', { exceptions: ['_', 'e', 'i'] }],
+  'id-match': [
+    'error',
+    '^_$|^[$_a-zA-Z]*[_a-zA-Z0-9]*[a-zA-Z0-9]*$|^[A-Z][_A-Z0-9]+[A-Z0-9]$',
+    {
+      onlyDeclarations: true,
+      properties: true
+    }
+  ],
+  'max-depth': 'error',
+  'max-params': ['error', 4],
+  'new-cap': 'error',
+  'no-alert': 'error',
+  'no-array-constructor': 'error',
+  'no-bitwise': 'error',
+  'no-caller': 'error',
+  'no-cond-assign': ['error', 'always'],
+  'no-console': 'warn',
+  'no-div-regex': 'error',
+  'no-duplicate-imports': 'error',
+  'no-else-return': 'error',
+  'no-eq-null': 'error',
+  'no-eval': 'error',
+  'no-extend-native': 'error',
+  'no-extra-bind': 'error',
+  'no-implied-eval': 'error',
+  'no-inline-comments': 'error',
+  'no-irregular-whitespace': ['error', { skipComments: false, skipStrings: false, skipTemplates: false }],
+  'no-iterator': 'error',
+  'no-labels': 'error',
+  'no-lone-blocks': 'error',
+  'no-lonely-if': 'error',
+  'no-loop-func': 'error',
+  'no-multi-str': 'error',
+  'no-nested-ternary': 'error',
+  'no-new': 'error',
+  'no-new-func': 'error',
+  'no-new-wrappers': 'error',
+  'no-object-constructor': 'error',
+  'no-octal-escape': 'error',
+  'no-proto': 'error',
+  'no-return-assign': 'error',
+  'no-script-url': 'error',
+  'no-self-compare': 'error',
+  'no-sequences': 'error',
+  'no-throw-literal': 'error',
+  'no-undef-init': 'error',
+  'no-underscore-dangle': 'error',
+  'no-unneeded-ternary': 'error',
+  'no-unused-expressions': 'error',
+  'no-unused-vars': ['error', { caughtErrors: 'none' }],
+  'no-use-before-define': 'error',
+  'no-useless-call': 'error',
+  'no-useless-concat': 'error',
+  'no-var': 'error',
+  'no-void': 'error',
+  'object-shorthand': 'error',
+  'operator-assignment': 'error',
+  'prefer-const': 'error',
+  'prefer-destructuring': [
+    'error',
+    {
+      AssignmentExpression: {
+        array: false,
+        object: false
+      },
+
+      VariableDeclarator: {
+        array: true,
+        object: true
+      }
+    },
+    {
+      enforceForRenamedProperties: false
+    }
+  ],
+  'prefer-spread': 'error',
+  'prefer-template': 'error',
+  'prettier/prettier': [
+    'error',
+    {
+      arrowParens: 'avoid',
+      printWidth: 120,
+      singleQuote: true,
+      trailingComma: 'none'
+    }
+  ],
+  radix: 'error',
+  'require-atomic-updates': 'off',
+  'require-await': 'error',
+  'vars-on-top': 'error',
+  yoda: 'error'
+};
+
+export const jsdocConfig = {
+  name: 'uphold/jsdoc',
+  plugins: {
+    jsdocPlugin
+  },
+  rules: {
+    // ...jsdocPlugin.configs['flat/recommended-error'].rules,
+    'jsdoc/no-defaults': 0,
+    'jsdoc/require-description-complete-sentence': [
+      'error',
+      {
+        abbreviations: ['e.g.', 'i.e.', 'etc.']
+      }
+    ],
+    'jsdoc/require-jsdoc': 0,
+    'jsdoc/tag-lines': 0
+  }
+};
+
+export const nodePluginConfig = {
+  name: 'uphold/nodePlugin',
+  plugins: {
+    'node-plugin': nodePlugin
+  },
+  rules: {
+    'node-plugin/no-mixed-requires': 'error',
+    'node-plugin/no-new-require': 'error',
+    'node-plugin/no-path-concat': 'error',
+    'node-plugin/no-process-env': 'error',
+    'node-plugin/no-process-exit': 'error',
+    'node-plugin/no-restricted-import': 'error',
+    'node-plugin/no-restricted-require': 'error',
+    'node-plugin/no-sync': 'error'
+  }
+};
+
+export const promisePluginConfig = {
+  name: 'uphold/promise',
+  plugins: { promisePlugin },
+  rules: {
+    'promise/prefer-await-to-then': 'error'
+  }
+};
+
+export const sortDestructureKeysConfig = {
+  name: 'uphold/sortDestructureKeys',
+  plugins: {
+    'sort-destructure-keys': sortDestructureKeysPlugin
+  },
+  rules: {
+    'sort-destructure-keys/sort-destructure-keys': 'error'
+  }
+};
+
+export const sortImportsRequiresConfig = {
+  name: 'uphold/sortImportsRequires',
+  plugins: {
+    'sort-imports-requires': sortImportsRequiresPlugin
+  },
+  rules: {
+    'sort-imports-requires/sort-imports': ['error', { unsafeAutofix: true, useOldSingleMemberSyntax: true }],
+    'sort-imports-requires/sort-requires': [
+      'error',
+      {
+        unsafeAutofix: true,
+        useAliases: false,
+        useOldSingleMemberSyntax: true
+      }
+    ]
+  }
+};
+
+export const sortKeysFixConfig = {
+  name: 'uphold/sortKeysFix',
+  plugins: {
+    'sort-keys-fix': sortKeysFixPlugin
+  },
+  rules: {
+    'sort-keys-fix/sort-keys-fix': ['error', 'asc', { natural: true }]
+  }
+};
+
+export const sqlTemplateConfig = {
+  name: 'uphold/sqlTemplate',
+  plugins: {
+    'sql-template': sqlTemplatePlugin
+  },
+  rules: {
+    'sql-template/no-unsafe-query': 'error'
+  }
+};
+
+export const stylisticConfig = {
+  name: 'uphold/stylistic',
+  plugins: {
+    '@stylistic': stylisticPlugin
+  },
+  rules: {
+    '@stylistic/no-tabs': ['error', { allowIndentationTabs: true }],
+    '@stylistic/padding-line-between-statements': [
+      'error',
+      {
+        blankLine: 'always',
+        next: 'return',
+        prev: '*'
+      },
+      {
+        blankLine: 'always',
+        next: '*',
+        prev: ['const', 'let', 'var']
+      },
+      {
+        blankLine: 'any',
+        next: ['const', 'let', 'var'],
+        prev: ['const', 'let', 'var']
+      }
+    ],
+    '@stylistic/spaced-comment': 'error'
+  }
+};
+
+export const upholdPluginConfig = {
+  name: 'uphold/upholdPlugin',
+  plugins: {
+    'uphold-plugin': { rules }
+  },
+  rules: {
+    'uphold-plugin/explicit-sinon-use-fake-timers': 'error'
+  }
+};

--- a/src/configs/javascript.js
+++ b/src/configs/javascript.js
@@ -1,0 +1,74 @@
+/**
+ * Module dependencies.
+ */
+
+import { defineConfig } from 'eslint/config';
+import {
+  eslintRules,
+  jsdocConfig,
+  nodePluginConfig,
+  promisePluginConfig,
+  sortDestructureKeysConfig,
+  sortImportsRequiresConfig,
+  sortKeysFixConfig,
+  sqlTemplateConfig,
+  stylisticConfig,
+  upholdPluginConfig
+} from '../common.js';
+import eslint from '@eslint/js';
+import globals from 'globals';
+import jsdoc from 'eslint-plugin-jsdoc';
+
+/**
+ * Uphold JavaScript configuration.
+ */
+
+const upholdJavascriptConfig = defineConfig([
+  {
+    languageOptions: {
+      ecmaVersion: 2022,
+      globals: globals.node,
+      parserOptions: {
+        ecmaFeatures: {
+          impliedStrict: true
+        }
+      }
+    },
+    name: 'uphold/languageOptions'
+  },
+  {
+    extends: [{ ...eslint.configs.recommended, name: 'eslint/recommended' }],
+    name: 'uphold/base',
+    rules: eslintRules
+  },
+  {
+    ...jsdocConfig,
+    rules: {
+      ...jsdoc.configs['flat/recommended-error'].rules,
+      ...jsdocConfig.rules
+    }
+  },
+  nodePluginConfig,
+  promisePluginConfig,
+  sortDestructureKeysConfig,
+  sortImportsRequiresConfig,
+  sortKeysFixConfig,
+  sqlTemplateConfig,
+  stylisticConfig,
+  upholdPluginConfig
+]);
+
+export const upholdBinScriptsConfig = {
+  files: ['**/bin/**', '**/scripts/**'],
+  name: 'uphold/scripts',
+  rules: {
+    'no-console': 'off',
+    'node-plugin/no-process-exit': 'off'
+  }
+};
+
+/**
+ * Export the configuration.
+ */
+
+export default upholdJavascriptConfig;

--- a/src/configs/jest.js
+++ b/src/configs/jest.js
@@ -1,0 +1,28 @@
+/**
+ * Module dependencies.
+ */
+
+import pluginJest from 'eslint-plugin-jest';
+
+/**
+ * Export Jest ESLint config.
+ */
+
+export const upholdJestConfig = {
+  languageOptions: {
+    globals: pluginJest.environments.globals
+  },
+  name: 'uphold/jest',
+  plugins: {
+    jest: pluginJest
+  },
+  rules: {
+    ...pluginJest.configs['flat/recommended'].rules,
+    'jest/prefer-called-with': 'error',
+    'jest/prefer-spy-on': 'warn',
+    'jest/prefer-to-be': 'error',
+    'jest/prefer-to-contain': 'error',
+    'jest/prefer-to-have-length': 'error',
+    'jest/prefer-todo': 'warn'
+  }
+};

--- a/src/configs/mocha.js
+++ b/src/configs/mocha.js
@@ -1,0 +1,29 @@
+/**
+ * Module dependencies.
+ */
+
+import globals from 'globals';
+import mocha from 'eslint-plugin-mocha';
+
+/**
+ * Uphold Mocha ESLint config.
+ */
+
+export const upholdMochaConfig = {
+  languageOptions: {
+    globals: {
+      ...globals.mocha,
+      ...globals.node
+    }
+  },
+  name: 'uphold/mocha',
+  plugins: {
+    mocha
+  },
+  rules: {
+    'mocha/no-exclusive-tests': 'error',
+    'mocha/no-identical-title': 'error',
+    'mocha/no-nested-tests': 'error',
+    'mocha/no-sibling-hooks': 'error'
+  }
+};

--- a/src/configs/typescript.js
+++ b/src/configs/typescript.js
@@ -1,0 +1,74 @@
+/**
+ * Module dependencies.
+ */
+
+import {
+  eslintRules,
+  jsdocConfig,
+  nodePluginConfig,
+  promisePluginConfig,
+  sortDestructureKeysConfig,
+  sortImportsRequiresConfig,
+  sortKeysFixConfig,
+  sqlTemplateConfig,
+  stylisticConfig,
+  upholdPluginConfig
+} from '../common.js';
+import eslint from '@eslint/js';
+import globals from 'globals';
+import jsdoc from 'eslint-plugin-jsdoc';
+import tseslint from 'typescript-eslint';
+
+/**
+ * Uphold TypeScript configuration.
+ */
+
+const upholdTypescriptConfig = tseslint.config([
+  {
+    extends: [{ ...eslint.configs.recommended, name: 'eslint/recommended' }],
+    languageOptions: {
+      ecmaVersion: 2022,
+      globals: globals.node,
+      parser: tseslint.parser,
+      parserOptions: {
+        sourceType: 'module',
+        tsconfigRootDir: './'
+      }
+    },
+    name: 'upholdTs/languageOptions'
+  },
+  {
+    extends: [tseslint.configs.eslintRecommended, tseslint.configs.recommended],
+    name: 'upholdTs/base',
+    plugins: {
+      '@typescript-eslint': tseslint
+    },
+    rules: {
+      ...eslintRules
+    }
+  },
+  {
+    name: 'upholdTs/jsdoc',
+    plugins: {
+      jsdoc
+    },
+    rules: {
+      ...jsdoc.configs['flat/recommended-typescript-error'].rules,
+      ...jsdocConfig.rules
+    }
+  },
+  nodePluginConfig,
+  promisePluginConfig,
+  sortDestructureKeysConfig,
+  sortImportsRequiresConfig,
+  sortKeysFixConfig,
+  sqlTemplateConfig,
+  stylisticConfig,
+  upholdPluginConfig
+]);
+
+/**
+ * Export the configuration.
+ */
+
+export default upholdTypescriptConfig;

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,9 @@ const languageOptions = {
   },
   parser: babelParser,
   parserOptions: {
+    ecmaFeatures: {
+      impliedStrict: true
+    },
     requireConfigFile: false
   },
   sourceType: 'module'
@@ -130,7 +133,7 @@ const upholdBaseConfig = defineConfig([
       'no-cond-assign': ['error', 'always'],
       'no-console': 'warn',
       'no-div-regex': 'error',
-      'no-dupe-keys': 'error',
+      // 'no-dupe-keys': 'error', // Already set by eslint:recommended
       'no-duplicate-imports': 'error',
       'no-else-return': 'error',
       'no-eq-null': 'error',

--- a/yarn.lock
+++ b/yarn.lock
@@ -169,7 +169,7 @@
   dependencies:
     eslint-visitor-keys "^3.4.3"
 
-"@eslint-community/regexpp@^4.11.0", "@eslint-community/regexpp@^4.12.1":
+"@eslint-community/regexpp@^4.10.0", "@eslint-community/regexpp@^4.11.0", "@eslint-community/regexpp@^4.12.1":
   version "4.12.1"
   resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.12.1.tgz#cfc6cffe39df390a3841cde2abccf92eaa7ae0e0"
   integrity sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==
@@ -636,6 +636,32 @@
   dependencies:
     parse-path "*"
 
+"@typescript-eslint/eslint-plugin@8.32.1":
+  version "8.32.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.32.1.tgz#9185b3eaa3b083d8318910e12d56c68b3c4f45b4"
+  integrity sha512-6u6Plg9nP/J1GRpe/vcjjabo6Uc5YQPAMxsgQyGC/I0RuukiG1wIe3+Vtg3IrSCVJDmqK3j8adrtzXSENRtFgg==
+  dependencies:
+    "@eslint-community/regexpp" "^4.10.0"
+    "@typescript-eslint/scope-manager" "8.32.1"
+    "@typescript-eslint/type-utils" "8.32.1"
+    "@typescript-eslint/utils" "8.32.1"
+    "@typescript-eslint/visitor-keys" "8.32.1"
+    graphemer "^1.4.0"
+    ignore "^7.0.0"
+    natural-compare "^1.4.0"
+    ts-api-utils "^2.1.0"
+
+"@typescript-eslint/parser@8.32.1":
+  version "8.32.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.32.1.tgz#18b0e53315e0bc22b2619d398ae49a968370935e"
+  integrity sha512-LKMrmwCPoLhM45Z00O1ulb6jwyVr2kr3XJp+G+tSEZcbauNnScewcQwtJqXDhXeYPDEjZ8C1SjXm015CirEmGg==
+  dependencies:
+    "@typescript-eslint/scope-manager" "8.32.1"
+    "@typescript-eslint/types" "8.32.1"
+    "@typescript-eslint/typescript-estree" "8.32.1"
+    "@typescript-eslint/visitor-keys" "8.32.1"
+    debug "^4.3.4"
+
 "@typescript-eslint/scope-manager@8.32.0":
   version "8.32.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.32.0.tgz#6be89f652780f0d3d19d58dc0ee107b1a9e3282c"
@@ -644,10 +670,33 @@
     "@typescript-eslint/types" "8.32.0"
     "@typescript-eslint/visitor-keys" "8.32.0"
 
+"@typescript-eslint/scope-manager@8.32.1":
+  version "8.32.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.32.1.tgz#9a6bf5fb2c5380e14fe9d38ccac6e4bbe17e8afc"
+  integrity sha512-7IsIaIDeZn7kffk7qXC3o6Z4UblZJKV3UBpkvRNpr5NSyLji7tvTcvmnMNYuYLyh26mN8W723xpo3i4MlD33vA==
+  dependencies:
+    "@typescript-eslint/types" "8.32.1"
+    "@typescript-eslint/visitor-keys" "8.32.1"
+
+"@typescript-eslint/type-utils@8.32.1":
+  version "8.32.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-8.32.1.tgz#b9292a45f69ecdb7db74d1696e57d1a89514d21e"
+  integrity sha512-mv9YpQGA8iIsl5KyUPi+FGLm7+bA4fgXaeRcFKRDRwDMu4iwrSHeDPipwueNXhdIIZltwCJv+NkxftECbIZWfA==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "8.32.1"
+    "@typescript-eslint/utils" "8.32.1"
+    debug "^4.3.4"
+    ts-api-utils "^2.1.0"
+
 "@typescript-eslint/types@8.32.0":
   version "8.32.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.32.0.tgz#a4a66b8876b8391970cf069b49572e43f1fc957a"
   integrity sha512-O5Id6tGadAZEMThM6L9HmVf5hQUXNSxLVKeGJYWNhhVseps/0LddMkp7//VDkzwJ69lPL0UmZdcZwggj9akJaA==
+
+"@typescript-eslint/types@8.32.1":
+  version "8.32.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.32.1.tgz#b19fe4ac0dc08317bae0ce9ec1168123576c1d4b"
+  integrity sha512-YmybwXUJcgGqgAp6bEsgpPXEg6dcCyPyCSr0CAAueacR/CCBi25G3V8gGQ2kRzQRBNol7VQknxMs9HvVa9Rvfg==
 
 "@typescript-eslint/typescript-estree@8.32.0":
   version "8.32.0"
@@ -662,6 +711,30 @@
     minimatch "^9.0.4"
     semver "^7.6.0"
     ts-api-utils "^2.1.0"
+
+"@typescript-eslint/typescript-estree@8.32.1":
+  version "8.32.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.32.1.tgz#9023720ca4ecf4f59c275a05b5fed69b1276face"
+  integrity sha512-Y3AP9EIfYwBb4kWGb+simvPaqQoT5oJuzzj9m0i6FCY6SPvlomY2Ei4UEMm7+FXtlNJbor80ximyslzaQF6xhg==
+  dependencies:
+    "@typescript-eslint/types" "8.32.1"
+    "@typescript-eslint/visitor-keys" "8.32.1"
+    debug "^4.3.4"
+    fast-glob "^3.3.2"
+    is-glob "^4.0.3"
+    minimatch "^9.0.4"
+    semver "^7.6.0"
+    ts-api-utils "^2.1.0"
+
+"@typescript-eslint/utils@8.32.1":
+  version "8.32.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.32.1.tgz#4d6d5d29b9e519e9a85e9a74e9f7bdb58abe9704"
+  integrity sha512-DsSFNIgLSrc89gpq1LJB7Hm1YpuhK086DRDJSNrewcGvYloWW1vZLHBTIvarKZDcAORIy/uWNx8Gad+4oMpkSA==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.7.0"
+    "@typescript-eslint/scope-manager" "8.32.1"
+    "@typescript-eslint/types" "8.32.1"
+    "@typescript-eslint/typescript-estree" "8.32.1"
 
 "@typescript-eslint/utils@^8.23.0":
   version "8.32.0"
@@ -679,6 +752,14 @@
   integrity sha512-1rYQTCLFFzOI5Nl0c8LUpJT8HxpwVRn9E4CkMsYfuN6ctmQqExjSTzzSk0Tz2apmXy7WU6/6fyaZVVA/thPN+w==
   dependencies:
     "@typescript-eslint/types" "8.32.0"
+    eslint-visitor-keys "^4.2.0"
+
+"@typescript-eslint/visitor-keys@8.32.1":
+  version "8.32.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.32.1.tgz#4321395cc55c2eb46036cbbb03e101994d11ddca"
+  integrity sha512-ar0tjQfObzhSaW3C3QNmTc5ofj0hDoNQ5XWrCy6zDyabdr0TWhCkClp+rywGNj/odAFBVzzJrK4tEq5M4Hmu4w==
+  dependencies:
+    "@typescript-eslint/types" "8.32.1"
     eslint-visitor-keys "^4.2.0"
 
 "@uphold/github-changelog-generator@^4.0.2":
@@ -1747,6 +1828,11 @@ graceful-fs@^4.2.4:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
+graphemer@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
+  integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
+
 has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
@@ -1814,6 +1900,11 @@ ignore@^5.2.0, ignore@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
+
+ignore@^7.0.0:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-7.0.4.tgz#a12c70d0f2607c5bf508fb65a40c75f037d7a078"
+  integrity sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==
 
 import-fresh@^3.2.1:
   version "3.3.1"
@@ -2964,6 +3055,15 @@ type-is@^2.0.0, type-is@^2.0.1:
     content-type "^1.0.5"
     media-typer "^1.1.0"
     mime-types "^3.0.0"
+
+typescript-eslint@^8.32.0:
+  version "8.32.1"
+  resolved "https://registry.yarnpkg.com/typescript-eslint/-/typescript-eslint-8.32.1.tgz#1784335c781491be528ff84ab666e2f0f7591fd1"
+  integrity sha512-D7el+eaDHAmXvrZBy1zpzSNIRqnCOrkwTgZxTu3MUqRWk8k0q9m9Ho4+vPf7iHtgUfrK/o8IZaEApsxPlHTFCg==
+  dependencies:
+    "@typescript-eslint/eslint-plugin" "8.32.1"
+    "@typescript-eslint/parser" "8.32.1"
+    "@typescript-eslint/utils" "8.32.1"
 
 undici@6.21.2:
   version "6.21.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -726,7 +726,7 @@
     semver "^7.6.0"
     ts-api-utils "^2.1.0"
 
-"@typescript-eslint/utils@8.32.1":
+"@typescript-eslint/utils@8.32.1", "@typescript-eslint/utils@^6.0.0 || ^7.0.0 || ^8.0.0":
   version "8.32.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.32.1.tgz#4d6d5d29b9e519e9a85e9a74e9f7bdb58abe9704"
   integrity sha512-DsSFNIgLSrc89gpq1LJB7Hm1YpuhK086DRDJSNrewcGvYloWW1vZLHBTIvarKZDcAORIy/uWNx8Gad+4oMpkSA==
@@ -1281,6 +1281,13 @@ eslint-plugin-es-x@^7.8.0:
     "@eslint-community/eslint-utils" "^4.1.2"
     "@eslint-community/regexpp" "^4.11.0"
     eslint-compat-utils "^0.5.1"
+
+eslint-plugin-jest@^28.11.0:
+  version "28.11.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-28.11.0.tgz#2641ecb4411941bbddb3d7cf8a8ff1163fbb510e"
+  integrity sha512-QAfipLcNCWLVocVbZW8GimKn5p5iiMcgGbRzz8z/P5q7xw+cNEpYqyzFMtIF/ZgF2HLOyy+dYBut+DoYolvqig==
+  dependencies:
+    "@typescript-eslint/utils" "^6.0.0 || ^7.0.0 || ^8.0.0"
 
 eslint-plugin-jsdoc@^50.6.14:
   version "50.6.14"


### PR DESCRIPTION
## Description

- Add TypeScript support, exporting 2 new separate configs:
  - `eslint-config-uphold/typescript` for TypeScript using `typescript-eslint`.
  - `eslint-config-uphold/javascript` for JavaScript keeping the same config.

- Split the config into individual config objects on `src/configs/common`, making it easier to configure rules specific to each plugin, while also improving its visibility when using the config inspector.

- Move the test-framework globals, plugins, and configs, to individual modules as such, so that each project can implement on a per-need basis. (this may be split into a separate PR)
- Add `eslint-plugin-jest` for the Jest-specific config.

This keeps compatibility with the current config version, while allowing for gradual adoption and iteration until finding a good setup that works for all sorts of projects.