### PR TITLE
Add `@vitest/eslint-plugin` for `vitest` linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,17 +58,23 @@
     "@uphold/github-changelog-generator": "^4.0.2",
     "eslint": "^9.27.0",
     "prettier": "^3.5.3",
-    "release-it": "^19.0.2"
+    "release-it": "^19.0.2",
+    "typescript": "^5.8.3"
   },
   "optionalDependencies": {
+    "@vitest/eslint-plugin": "^1.2.0",
     "eslint-plugin-jest": "^28.11.0"
   },
   "peerDependencies": {
     "eslint": "~9.27.0",
-    "prettier": ">=3.0.0"
+    "prettier": ">=3.0.0",
+    "typescript": ">=4.8.4 <=5.9.0"
   },
   "peerDependenciesMeta": {
     "prettier": {
+      "optional": true
+    },
+    "typescript": {
       "optional": true
     }
   },

--- a/src/configs/vitest.js
+++ b/src/configs/vitest.js
@@ -2,20 +2,65 @@
  * Module dependencies.
  */
 
-import globals from 'globals';
+import { isModuleAvailable, loadModule } from '../utils/load-module.js';
+
+/**
+ * Check if `@vitest/eslint-plugin` and its dependencies are available.
+ */
+
+const isTypeScriptAvailable = isModuleAvailable('typescript');
+const isVitestPluginAvailable = isModuleAvailable('@vitest/eslint-plugin');
+const isVitestAvailable = isModuleAvailable('vitest');
 
 /**
  * Uphold Vitest ESLint config.
  * @type {import('@eslint/config-helpers').ConfigWithExtends}
- * @todo Add `@vitest/eslint-plugin` and/or `eslint-plugin-vitest-globals`.
  */
+let upholdVitestConfig;
 
-const upholdVitestConfig = {
-  languageOptions: {
-    globals: globals.vitest
-  },
-  name: 'uphold/vitest-globals'
-};
+if (isVitestPluginAvailable && isTypeScriptAvailable && isVitestAvailable) {
+  const { default: vitestPlugin } = await loadModule('@vitest/eslint-plugin');
+
+  upholdVitestConfig = {
+    extends: [vitestPlugin.configs.recommended],
+    languageOptions: vitestPlugin.configs.env.languageOptions,
+    name: 'uphold/vitest-plugin-config',
+    rules: {
+      'vitest/no-commented-out-tests': 'warn',
+      'vitest/no-disabled-tests': 'warn',
+      'vitest/no-focused-tests': 'error',
+      'vitest/no-interpolation-in-snapshots': 'error',
+      'vitest/no-mocks-import': 'error',
+      'vitest/no-standalone-expect': 'error',
+      'vitest/no-test-prefixes': 'error',
+      'vitest/prefer-expect-resolves': 'warn',
+      'vitest/prefer-to-have-length': 'warn'
+    }
+  };
+} else if (isVitestAvailable) {
+  if (!isTypeScriptAvailable) {
+    console.warn('`typescript` is not installed, Vitest linting will be disabled');
+  }
+
+  if (!isVitestPluginAvailable) {
+    console.warn('`@vitest/eslint-plugin` is not installed, Vitest linting will be disabled');
+  }
+
+  const globals = await loadModule('globals');
+
+  upholdVitestConfig = {
+    languageOptions: {
+      globals: globals.vitest
+    },
+    name: 'uphold/vitest-globals'
+  };
+} else {
+  console.error('Vitest is not installed, this config will be empty');
+
+  upholdVitestConfig = {
+    name: 'uphold/vitest-empty'
+  };
+}
 
 /**
  * Export the configuration.

--- a/src/utils/load-module.js
+++ b/src/utils/load-module.js
@@ -29,11 +29,13 @@ function isModuleAvailable(moduleName) {
  * Module map for dynamic imports.
  *
  * @typedef {{
+ *  "@vitest/eslint-plugin": import('@vitest/eslint-plugin'),
  *  "eslint-plugin-jest": import('eslint-plugin-jest'),
  *  "eslint-plugin-mocha": import('eslint-plugin-mocha'),
  *  "globals": import('globals'),
  *  "jest": import('jest'),
- *  "mocha": import('mocha')
+ *  "mocha": import('mocha'),
+ *  "typescript": import('typescript')
  * }} ModuleMap
  */
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -649,7 +649,7 @@
     semver "^7.6.0"
     ts-api-utils "^2.1.0"
 
-"@typescript-eslint/utils@^6.0.0 || ^7.0.0 || ^8.0.0", "@typescript-eslint/utils@^8.23.0":
+"@typescript-eslint/utils@^6.0.0 || ^7.0.0 || ^8.0.0", "@typescript-eslint/utils@^8.23.0", "@typescript-eslint/utils@^8.24.0":
   version "8.32.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.32.1.tgz#4d6d5d29b9e519e9a85e9a74e9f7bdb58abe9704"
   integrity sha512-DsSFNIgLSrc89gpq1LJB7Hm1YpuhK086DRDJSNrewcGvYloWW1vZLHBTIvarKZDcAORIy/uWNx8Gad+4oMpkSA==
@@ -677,6 +677,13 @@
     ini "^2.0.0"
     look-it-up "^2.1.0"
     moment "^2.29.1"
+
+"@vitest/eslint-plugin@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@vitest/eslint-plugin/-/eslint-plugin-1.2.0.tgz#ce4a9a8a4e27e199c9ae9acdf3eda5ba3164e2c4"
+  integrity sha512-6vn3QDy+ysqHGkbH9fU9uyWptqNc638dgPy0uAlh/XpniTBp+0WeVlXGW74zqggex/CwYOhK8t5GVo/FH3NMPw==
+  dependencies:
+    "@typescript-eslint/utils" "^8.24.0"
 
 acorn-jsx@^5.2.0, acorn-jsx@^5.3.2:
   version "5.3.2"
@@ -2494,6 +2501,11 @@ type-fest@^2.5.1:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
   integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
+
+typescript@^5.8.3:
+  version "5.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.3.tgz#92f8a3e5e3cf497356f4178c34cd65a7f5e8440e"
+  integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==
 
 undici@6.21.2:
   version "6.21.2"


### PR DESCRIPTION
## Description

- Add `@vitest/eslint-plugin` for projects using `vitest`.

It's added as an optional module, reachable from `eslint-config-uphold/configs/vitest`, and resolves automatically depending on the available dependencies:

| Available dependencies | Result |
| :-------- | :----- |
| Without `vitest` | ❌  Does not load, logging a warning. |
| With `vitest`, without `typescript` or `@vitest/eslint-plugin` | ⚠️  Loads `vitest` globals. |
| With `vitest`, `@vitest/eslint-plugin`, and `typescript` | ✅  Loads the plugin and recommended config. |

## Related PRs

- Rebased on https://github.com/uphold/eslint-config-uphold/pull/101