### PR TITLE
Update `prettier@3.6.1` and `eslint-plugin-prettier@5.5.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-jsdoc": "^50.8.0",
     "eslint-plugin-mocha": "^11.1.0",
     "eslint-plugin-n": "^17.20.0",
-    "eslint-plugin-prettier": "^5.5.0",
+    "eslint-plugin-prettier": "^5.5.1",
     "eslint-plugin-promise": "^7.2.1",
     "eslint-plugin-sort-destructure-keys": "^2.0.0",
     "eslint-plugin-sort-imports-requires": "^2.0.0",
@@ -51,7 +51,7 @@
     "@types/eslint": "^9.6.1",
     "@uphold/github-changelog-generator": "^4.0.2",
     "eslint": "~9.29.0",
-    "prettier": "^3.5.3",
+    "prettier": "^3.6.1",
     "release-it": "^19.0.3"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1130,10 +1130,10 @@ eslint-plugin-n@^17.20.0:
     semver "^7.6.3"
     ts-declaration-location "^1.0.6"
 
-eslint-plugin-prettier@^5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.0.tgz#cf763962f90bad035db03ca008ffb0c9b359fb16"
-  integrity sha512-8qsOYwkkGrahrgoUv76NZi23koqXOGiiEzXMrT8Q7VcYaUISR+5MorIUxfWqYXN0fN/31WbSrxCxFkVQ43wwrA==
+eslint-plugin-prettier@^5.5.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.1.tgz#470820964de9aedb37e9ce62c3266d2d26d08d15"
+  integrity sha512-dobTkHT6XaEVOo8IO90Q4DOSxnm3Y151QxPJlM/vKC0bVy+d6cVWQZLlFiuZPP0wS6vZwSKeJgKkcS+KfMBlRw==
   dependencies:
     prettier-linter-helpers "^1.0.0"
     synckit "^0.11.7"
@@ -2161,10 +2161,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.5.3.tgz#4fc2ce0d657e7a02e602549f053b239cb7dfe1b5"
-  integrity sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==
+prettier@^3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.6.1.tgz#cc3bce21c09a477b1e987b76ce9663925d86ae44"
+  integrity sha512-5xGWRa90Sp2+x1dQtNpIpeOQpTDBs9cZDmA/qs2vDNN2i18PdapqY7CmBeyLlMuGqXJRIOPaCaVZTLNQRWUH/A==
 
 protocols@^2.0.0, protocols@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
## Description

- Update `prettier` to `3.6.1`, which includes the new experimental fast CLI and new OXC and Hemes plugins.
  See the announcement on https://prettier.io/blog/2025/06/23/3.6.0.
- Update `eslint-plugin-prettier@5.5.1`.