### PR TITLE
Add `if` to padding-line-between-statements

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -84,7 +84,7 @@ const upholdBaseConfig = defineConfig([
         {
           blankLine: 'always',
           next: '*',
-          prev: ['const', 'let', 'var']
+          prev: ['const', 'if', 'let', 'var']
         },
         {
           blankLine: 'any',

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -32,6 +32,12 @@ function funcThatReturns(bar) {
 
 funcThatReturns('foo');
 
+if (noop()) {
+  noop();
+}
+
+noop();
+
 // `@stylistic/spaced-comment`.
 // spaced comment.
 

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -18,6 +18,11 @@ function funcThatReturns(bar) {
 
 funcThatReturns('foo');
 
+if (noop()) {
+  noop();
+}
+noop();
+
 // `@stylistic/spaced-comment`.
 //Comment missing space.
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -35,6 +35,7 @@ describe('eslint-config-uphold', () => {
     assert.deepEqual(rules, [
       '@stylistic/padding-line-between-statements',
       '@stylistic/padding-line-between-statements',
+      '@stylistic/padding-line-between-statements',
       '@stylistic/spaced-comment',
       'array-callback-return',
       'no-console',


### PR DESCRIPTION
Adds `if` to the statements requiring a padding blank like after the block.