### PR TITLE
Add `@typescript-eslint/array-type` rule

### DIFF
--- a/src/configs/typescript.js
+++ b/src/configs/typescript.js
@@ -138,6 +138,7 @@ export async function createTypeScriptConfig(moduleType = 'module', { ecmaVersio
         },
         rules: {
           ...eslintRules,
+          '@typescript-eslint/array-type': ['error', { default: 'array-simple', readonly: 'array-simple' }],
           '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_.+' }],
           'no-unused-expressions': 'off',
           'no-unused-vars': 'off'

--- a/test/src/configs/typescript.test.js
+++ b/test/src/configs/typescript.test.js
@@ -77,6 +77,15 @@ describe('TypeScript config', () => {
         );
 
         assert.ok(hasTypescriptRules, 'Should have TypeScript rule overrides');
+
+        const configWithArrayType = config.find(cfg => cfg.rules?.['@typescript-eslint/array-type']);
+
+        assert.ok(configWithArrayType, 'Should have `@typescript-eslint/array-type` rule');
+        assert.deepStrictEqual(
+          configWithArrayType.rules?.['@typescript-eslint/array-type'],
+          ['error', { default: 'array-simple', readonly: 'array-simple' }],
+          'Should use `array-simple` option'
+        );
       });
 
       it('should return config with `typescript-eslint` for `commonjs` type', async () => {


### PR DESCRIPTION
## Description

Following DPAY conversation [here](https://uphold.slack.com/archives/C02DCB5S59D/p1776940210687139)

Adds the [`@typescript-eslint/array-type`](https://typescript-eslint.io/rules/array-type/#array-simple) rule with the `array-simple` option to enforce a consistent style for TypeScript array type declarations.

- **Simple types** (primitives like `string`, `number`, or type references like `MyType`) → use the shorthand `T[]` / `readonly T[]`
- **Complex types** (unions, intersections, objects, functions, etc.) → use the generic `Array<T>` / `ReadonlyArray<T>`

### Examples

```ts
// ✅ Correct
string[]
MyType[]
readonly string[]

Array<string | number>         // union — complex
Array<() => void>              // function — complex
ReadonlyArray<{ id: number }>  // object — complex

// ❌ Incorrect
Array<string>                  // simple type, should be string[]
(string | number)[]            // complex type, should be Array<string | number>
```

## References

- https://typescript-eslint.io/rules/array-type/#array-simple