### PR TITLE
Drop support for Node v20 and set ECMAScript 2024 as default

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,23 +7,23 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20, 22, 24]
+        node: [22, 24, 26]
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v5
+      - name: Checkout code
+        uses: actions/checkout@v6
 
-    - name: Setup Node.js version
-      uses: actions/setup-node@v6
-      with:
-        node-version: ${{ matrix.node }}
-        cache: 'yarn'
+      - name: Setup Node.js version
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'yarn'
 
-    - name: Install dependencies
-      run: yarn install --frozen-lockfile
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
 
-    - name: Run lint
-      run: yarn lint
+      - name: Run lint
+        run: yarn lint
 
-    - name: Run tests
-      run: yarn test
+      - name: Run tests
+        run: yarn test

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -9,6 +9,10 @@ This file contains migration guides for major versions of `eslint-config-uphold`
 ESLint v10 introduces some breaking changes. See the [ESLint v9 to v10 migration guide](https://eslint.org/docs/latest/use/migrating-to-v10) for more details.
 To deal with plugins that haven't been updated to support ESLint v9 nor v10, it may be possible to use `@eslint/compat`'s helper functions.
 
+## Dropped support for Node.js v20
+
+Node.js >= v22.12.0 is required, as it uses `require('esm')` to support ESM from certain plugins, dropping support for Node.js v20, which has reached its end-of-life.
+
 ### `eslint-plugin-n` renaming
 
 The plugin `eslint-plugin-n` got renamed from `node-plugin` to `n` to align with the official naming.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install eslint eslint-config-uphold prettier --save-dev
 ```
 
 > [!WARNING]
-> Node.js minimum versions are `v24.0.0`, `v22.12.0` and `v20.19.0`, as `@stylistic/eslint-plugin-js` depends on the `require('esm')` module from `v4.0.0`.
+> The minimum Node.js versions are `v22.12.0`, `v24.0.0`, as certain plugins depend on `require('esm')`, while matching the minimum versions supported by ESLint v10.
 
 ## Usage
 
@@ -108,12 +108,12 @@ export default upholdTypescriptConfig;
 
 The TypeScript config assumes ESM by default.
 If your project uses CJS, you can create a custom config using the `createTypeScriptConfig` factory.
-This can also be used to specify a `ecmaVersion` other than the default `2022`.
+This can also be used to specify a `ecmaVersion` other than the default `2024`.
 
 ```js
 import { createTypeScriptConfig } from 'eslint-config-uphold/configs';
 
-export default await createTypeScriptConfig('commonjs', { ecmaVersion: 2024 }); // 'module' for ESM, 'commonjs' for CJS.
+export default await createTypeScriptConfig('commonjs', { ecmaVersion: 2025 }); // 'module' for ESM, 'commonjs' for CJS.
 ```
 
 ### JavaScript
@@ -137,12 +137,12 @@ export default upholdJavascriptConfig;
 
 The JavaScript config assumes CJS by default.
 If your project uses ESM, you can create a custom config using the `createJavaScriptConfig` factory.
-This can also be used to specify a `ecmaVersion` other than the default `2022`.
+This can also be used to specify a `ecmaVersion` other than the default `2024`.
 
 ```js
 import { createJavaScriptConfig } from 'eslint-config-uphold/configs';
 
-export default createJavaScriptConfig('module', { ecmaVersion: 2024 }); // 'module' for ESM, 'commonjs' for CJS.
+export default createJavaScriptConfig('module', { ecmaVersion: 2025 }); // 'module' for ESM, 'commonjs' for CJS.
 ```
 
 ### Custom rules

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,23 +1,14 @@
 {
   "compilerOptions": {
-    "alwaysStrict": true,
-    "baseUrl": ".",
     "checkJs": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["ES2022"],
+    "lib": ["ES2024"],
     "module": "NodeNext",
     "moduleResolution": "nodenext",
     "noFallthroughCasesInSwitch": true,
-    "noImplicitAny": true,
     "noImplicitReturns": true,
-    "noImplicitThis": true,
-    "paths": {
-      "src/*": ["./src/*"],
-      "test/*": ["./test/*"]
-    },
     "skipLibCheck": false,
-    "strict": true,
-    "useUnknownInCatchVariables": true
+    "strict": true
   },
   "exclude": ["node_modules"],
   "typeAcquisition": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@fastify/pre-commit": "^2.2.1",
-    "@types/node": "24.12.2",
+    "@types/node": "^24",
     "@uphold/github-changelog-generator": "^4.0.2",
     "@vitest/eslint-plugin": "^1.6.17",
     "eslint": "~10.3.0",
@@ -96,7 +96,14 @@
     "lint"
   ],
   "engines": {
-    "node": "^20.19.0 || ^22.12.0 || >=24"
+    "node": "^22.12.0 || >=24"
+  },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": "24",
+      "onFail": "ignore"
+    }
   },
   "type": "module"
 }

--- a/src/configs/common.js
+++ b/src/configs/common.js
@@ -24,7 +24,7 @@ const isSinonAvailable = isModuleAvailable('sinon');
  * Default ECMAScript version for configs.
  * @type {import('eslint').Linter.LanguageOptions['ecmaVersion']}
  */
-export const defaultEcmaVersion = 2022;
+export const defaultEcmaVersion = 2024;
 
 /**
  * ESLint base rules.

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ import stylistic from '@stylistic/eslint-plugin';
  */
 
 const languageOptions = {
-  ecmaVersion: 2022,
+  ecmaVersion: 2024,
   globals: globals.node,
   sourceType: 'module'
 };

--- a/test/src/configs/javascript.test.js
+++ b/test/src/configs/javascript.test.js
@@ -13,7 +13,7 @@ import globals from 'globals';
 
 describe('JavaScript config', () => {
   describe('createJavaScriptConfig()', () => {
-    it('should return config with `commonjs` and `ecmaVersion` 2022 by default', () => {
+    it('should return config with `commonjs` and `ecmaVersion` 2024 by default', () => {
       const config = createJavaScriptConfig();
 
       assert.ok(Array.isArray(config), 'Should return an array');
@@ -37,8 +37,8 @@ describe('JavaScript config', () => {
       assert.strictEqual(
         // @ts-expect-error configWithLangOptions could be undefined from `config.find`.
         configWithLangOptions.languageOptions.ecmaVersion,
-        2022,
-        'Should use 2022 `ecmaVersion` by default'
+        2024,
+        'Should use 2024 `ecmaVersion` by default'
       );
       assert.ok(
         // @ts-expect-error Incomplete typing for `parserOptions`.
@@ -70,8 +70,8 @@ describe('JavaScript config', () => {
       );
     });
 
-    it('should return config with `module` type and `ecmaVersion` 2024', () => {
-      const config = createJavaScriptConfig('module', { ecmaVersion: 2024 });
+    it('should return config with `module` type and `ecmaVersion` 2025', () => {
+      const config = createJavaScriptConfig('module', { ecmaVersion: 2025 });
 
       assert.ok(Array.isArray(config), 'Should return an array');
       assert.ok(config.length > 0, 'Config array should not be empty');
@@ -90,7 +90,7 @@ describe('JavaScript config', () => {
         'Should use `globals.nodeBuiltin` for module'
       );
       // @ts-expect-error configWithLangOptions could be undefined from `config.find`.
-      assert.strictEqual(configWithLangOptions.languageOptions.ecmaVersion, 2024, 'Should use `ecmaVersion` 2024');
+      assert.strictEqual(configWithLangOptions.languageOptions.ecmaVersion, 2025, 'Should use `ecmaVersion` 2025');
       assert.ok(
         // @ts-expect-error Incomplete typing for `parserOptions`.
         configWithLangOptions.languageOptions.parserOptions?.ecmaFeatures?.impliedStrict,

--- a/yarn.lock
+++ b/yarn.lock
@@ -432,10 +432,10 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
-"@types/node@24.12.2":
-  version "24.12.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.12.2.tgz#353cb161dbf1785ea25e8829ba7ec574c5c629ac"
-  integrity sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==
+"@types/node@^24":
+  version "24.12.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.12.4.tgz#2709745569811dcbdc57c097fafdd387c6330382"
+  integrity sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==
   dependencies:
     undici-types "~7.16.0"
 


### PR DESCRIPTION
## Description

- Removes Node v20 and adds Node v26 from the CI test matrix
- Sets ECMAScript 2024 as the default version.
- Adds `devEngines` with `runtime` as Node v24, the current LTS, to `package.json`.
- Updates the README.md and MIGRATIONS.md to reflect the changes.
- Updates `jsconfig.json` to use ECMAScript 2024 and removes `baseUrl` and `paths` as they are no longer needed, along with other compiler options made redundant by `strict`.