### PR TITLE
Unify config entry points and refactor config architecture

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -46,11 +46,12 @@ Ensure you have it installed in your project if you use the Mocha test framework
 
 The package is now ESM-only. Your ESLint configuration must use ESM syntax (e.g. `eslint.config.mjs` on a CommonJS project).
 
-### `eslint-config-uphold/configs`
+### Unified imports, removing `eslint-config-uphold/configs`
 
-If you're using `eslint-config-uphold/configs` to import test framework configs, update the import to `eslint-config-uphold` directly instead, as the `configs` entry point has been removed.
+The `eslint-config-uphold/configs` entry point is removed.
+All configs are now exported directly from `eslint-config-uphold`.
 
-So instead of:
+Instead of:
 
 ```js
 import { defineConfig } from 'eslint/config';
@@ -63,6 +64,27 @@ Use:
 ```js
 import { defineConfig } from 'eslint/config';
 import { javascript as upholdJavascriptConfig, jest as upholdJestConfig } from 'eslint-config-uphold';
+```
+
+### `explicit-sinon-use-fake-timers` behavioral difference
+
+The default export always enables `uphold-plugin/explicit-sinon-use-fake-timers` as `'error'`, while the individual `javascript` and `typescript` named exports only enable it conditionally when `sinon` is detected as an installed dependency.
+
+If you are switching from the default export to the `javascript` or `typescript` named exports and your project uses `sinon`, ensure `sinon` is listed in your `package.json` so the rule is automatically enabled. Alternatively, you can enable it manually:
+
+```js
+import { defineConfig } from 'eslint/config';
+import { javascript as upholdJavascriptConfig } from 'eslint-config-uphold';
+
+export default defineConfig([
+  {
+    extends: [upholdJavascriptConfig],
+    files: ['**/*.js'],
+    rules: {
+      'uphold-plugin/explicit-sinon-use-fake-timers': 'error'
+    }
+  }
+]);
 ```
 
 ## v5 to v6

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -66,6 +66,24 @@ import { defineConfig } from 'eslint/config';
 import { javascript as upholdJavascriptConfig, jest as upholdJestConfig } from 'eslint-config-uphold';
 ```
 
+### Language configs no longer include `files`
+
+The `javascript` and `typescript` configs no longer include a `files` property. You must specify which files each config applies to, unless you want them to apply to all files:
+
+```js
+import { defineConfig } from 'eslint/config';
+import { javascript as upholdJavascriptConfig } from 'eslint-config-uphold';
+
+export default defineConfig([
+  {
+    extends: [upholdJavascriptConfig],
+    files: ['**/*.js', '**/*.jsx'] // You must specify this.
+  }
+]);
+```
+
+This gives you full control over file targeting and avoids conflicts with file extensions that have fixed module types (`.cjs`/`.mjs` for JavaScript, `.cts`/`.mts` for TypeScript), while also allowing for more flexibility in mixed codebases and if using ESLint for other languages, such as `@eslint/json` or `@eslint/markdown`.
+
 ### `explicit-sinon-use-fake-timers` behavioral difference
 
 The default export always enables `uphold-plugin/explicit-sinon-use-fake-timers` as `'error'`, while the individual `javascript` and `typescript` named exports only enable it conditionally when `sinon` is detected as an installed dependency.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ To automatically fix all lint issues, use the `--fix` option:
 npm run lint --fix
 ```
 
+The default configuration uses CommonJS with ECMAScript 2024.
+
+The `javascript` and `typescript` named exports also use ECMAScript 2024.
+
 ### TypeScript
 
 A TypeScript-specific config using `typescript-eslint` is available.
@@ -166,12 +170,12 @@ export default defineConfig([
 
 This config includes custom Uphold-specific rules, under `uphold-plugin`.
 
-| Rule                                                                        | Enabled in default config? | Fix?  |
-| --------------------------------------------------------------------------- | -------------------------- | ----- |
-| [`database-migration-filename-format`](#database-migration-filename-format) | False                      | False |
-| [`explicit-sinon-use-fake-timers`](#explicit-sinon-use-fake-timers)         | True                       | False |
-| [`no-trailing-period-in-log-messages`](#no-trailing-period-in-log-messages) | True                       | True  |
-| [`require-comment-punctuation`](#require-comment-punctuation)               | True                       | True  |
+| Rule                                                                        | Enabled in default config?       | Fix?  |
+| --------------------------------------------------------------------------- | -------------------------------- | ----- |
+| [`database-migration-filename-format`](#database-migration-filename-format) | False                            | False |
+| [`explicit-sinon-use-fake-timers`](#explicit-sinon-use-fake-timers)         | True (when `sinon` is installed) | False |
+| [`no-trailing-period-in-log-messages`](#no-trailing-period-in-log-messages) | True                             | True  |
+| [`require-comment-punctuation`](#require-comment-punctuation)               | True                             | True  |
 
 #### `database-migration-filename-format`
 
@@ -196,6 +200,8 @@ export default defineConfig([
 #### `explicit-sinon-use-fake-timers`
 
 Enforces explicit configuration when using Sinon's `useFakeTimers()` by requiring the `toFake` option to be specified. This ensures that only the intended timer functions are faked, reducing the risk of unintended side effects in tests.
+
+This rule is automatically enabled when `sinon` is detected as an installed dependency. The default export (`upholdConfig`) always enables this rule, while the individual `javascript` and `typescript` configs only enable it conditionally.
 
 **Valid:**
 

--- a/README.md
+++ b/README.md
@@ -326,6 +326,9 @@ import { javascript, jest, mocha, typescript, vitest } from 'eslint-config-uphol
 > [!NOTE]
 > Test configs use top-level `await` for dynamic module detection and are **ESM-only**. If your project uses CommonJS, your `eslint.config.mjs` still supports `import()` and top-level `await`.
 
+> [!NOTE]
+> Missing optional plugin dependencies emit a `process.emitWarning()` notice (type `UpholdEslintWarning`) instead of writing to `console.warn`. These warnings are deduplicated by Node.js and can be suppressed with `--no-warnings` or `NODE_NO_WARNINGS=1`.
+
 ### Custom parsers
 
 From [ESLint's docs > Configure a Parser](https://eslint.org/docs/latest/use/configure/parser):

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ import tseslint from 'typescript-eslint';
 export default defineConfig([
   {
     extends: [upholdTypescriptConfig],
+    files: ['**/*.{ts,tsx}'],
     name: 'project-name/uphold-typescript',
     rules: {
       'jsdoc/no-types': 'warn'
@@ -101,9 +102,15 @@ export default defineConfig([
 It's also possible to use the config without `typescript-eslint`. Minimal setup would look like the following:
 
 ```js
+import { defineConfig } from 'eslint/config';
 import { typescript as upholdTypescriptConfig } from 'eslint-config-uphold';
 
-export default upholdTypescriptConfig;
+export default defineConfig([
+  {
+    extends: [upholdTypescriptConfig],
+    files: ['**/*.{ts,tsx}']
+  }
+]);
 ```
 
 The TypeScript config assumes ESM by default.
@@ -111,9 +118,15 @@ If your project uses CJS, you can create a custom config using the `createTypeSc
 This can also be used to specify a `ecmaVersion` other than the default `2024`.
 
 ```js
+import { defineConfig } from 'eslint/config';
 import { createTypeScriptConfig } from 'eslint-config-uphold';
 
-export default await createTypeScriptConfig('commonjs', { ecmaVersion: 2025 }); // 'module' for ESM, 'commonjs' for CJS.
+export default defineConfig([
+  {
+    extends: [await createTypeScriptConfig('commonjs', { ecmaVersion: 2025 })], // 'module' for ESM, 'commonjs' for CJS.
+    files: ['**/*.{ts,cts,tsx}']
+  }
+]);
 ```
 
 ### JavaScript
@@ -124,15 +137,13 @@ Likewise, a JavaScript-specific config is exported. The usage is similar to Type
 import { defineConfig, globalIgnores } from 'eslint/config';
 import { javascript as upholdJavascriptConfig } from 'eslint-config-uphold';
 
-export default defineConfig([upholdJavascriptConfig, globalIgnores(['coverage'])]);
-```
-
-If not wanting to extend the config, it could even be used like the following:
-
-```js
-import { javascript as upholdJavascriptConfig } from 'eslint-config-uphold';
-
-export default upholdJavascriptConfig;
+export default defineConfig([
+  {
+    extends: [upholdJavascriptConfig],
+    files: ['**/*.{js,jsx}']
+  },
+  globalIgnores(['coverage'])
+]);
 ```
 
 The JavaScript config assumes CJS by default.
@@ -140,9 +151,15 @@ If your project uses ESM, you can create a custom config using the `createJavaSc
 This can also be used to specify a `ecmaVersion` other than the default `2024`.
 
 ```js
+import { defineConfig } from 'eslint/config';
 import { createJavaScriptConfig } from 'eslint-config-uphold';
 
-export default createJavaScriptConfig('module', { ecmaVersion: 2025 }); // 'module' for ESM, 'commonjs' for CJS.
+export default defineConfig([
+  {
+    extends: [createJavaScriptConfig('module', { ecmaVersion: 2025 })], // 'module' for ESM, 'commonjs' for CJS.
+    files: ['**/*.{js,mjs,jsx}']
+  }
+]);
 ```
 
 ### Custom rules

--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ npm run lint --fix
 
 ### TypeScript
 
-A TypeScript-specific config using `typescript-eslint` is available under `eslint-config-uphold/configs/`.
+A TypeScript-specific config using `typescript-eslint` is available.
 
 It can be used like this, on a `eslint.config.mjs` file:
 
 ```js
 import { defineConfig, globalIgnores } from 'eslint/config';
-import { typescript as upholdTypescriptConfig } from 'eslint-config-uphold/configs';
+import { typescript as upholdTypescriptConfig } from 'eslint-config-uphold';
 import tseslint from 'typescript-eslint';
 
 export default defineConfig([
@@ -101,7 +101,7 @@ export default defineConfig([
 It's also possible to use the config without `typescript-eslint`. Minimal setup would look like the following:
 
 ```js
-import { typescript as upholdTypescriptConfig } from 'eslint-config-uphold/configs';
+import { typescript as upholdTypescriptConfig } from 'eslint-config-uphold';
 
 export default upholdTypescriptConfig;
 ```
@@ -111,18 +111,18 @@ If your project uses CJS, you can create a custom config using the `createTypeSc
 This can also be used to specify a `ecmaVersion` other than the default `2024`.
 
 ```js
-import { createTypeScriptConfig } from 'eslint-config-uphold/configs';
+import { createTypeScriptConfig } from 'eslint-config-uphold';
 
 export default await createTypeScriptConfig('commonjs', { ecmaVersion: 2025 }); // 'module' for ESM, 'commonjs' for CJS.
 ```
 
 ### JavaScript
 
-Likewise, a JavaScript-specific config is exported under `eslint-config-uphold/configs/`. The usage is similar to TypeScript's config:
+Likewise, a JavaScript-specific config is exported. The usage is similar to TypeScript's config:
 
 ```js
 import { defineConfig, globalIgnores } from 'eslint/config';
-import { javascript as upholdJavascriptConfig } from 'eslint-config-uphold/configs';
+import { javascript as upholdJavascriptConfig } from 'eslint-config-uphold';
 
 export default defineConfig([upholdJavascriptConfig, globalIgnores(['coverage'])]);
 ```
@@ -130,7 +130,7 @@ export default defineConfig([upholdJavascriptConfig, globalIgnores(['coverage'])
 If not wanting to extend the config, it could even be used like the following:
 
 ```js
-import { javascript as upholdJavascriptConfig } from 'eslint-config-uphold/configs';
+import { javascript as upholdJavascriptConfig } from 'eslint-config-uphold';
 
 export default upholdJavascriptConfig;
 ```
@@ -140,7 +140,7 @@ If your project uses ESM, you can create a custom config using the `createJavaSc
 This can also be used to specify a `ecmaVersion` other than the default `2024`.
 
 ```js
-import { createJavaScriptConfig } from 'eslint-config-uphold/configs';
+import { createJavaScriptConfig } from 'eslint-config-uphold';
 
 export default createJavaScriptConfig('module', { ecmaVersion: 2025 }); // 'module' for ESM, 'commonjs' for CJS.
 ```
@@ -278,7 +278,7 @@ To use them, import the config directly in your `eslint.config.mjs` file:
 
 ```js
 import { defineConfig } from 'eslint/config';
-import { mocha as upholdMochaConfig } from 'eslint-config-uphold/configs';
+import { mocha as upholdMochaConfig } from 'eslint-config-uphold';
 import upholdConfig from 'eslint-config-uphold';
 
 export default defineConfig([
@@ -294,10 +294,10 @@ export default defineConfig([
 ]);
 ```
 
-Those can be imported from `eslint-config-uphold/configs`:
+All configs can be imported from `eslint-config-uphold`:
 
 ```js
-import { jest, mocha, vitest } from 'eslint-config-uphold/configs';
+import { javascript, jest, mocha, typescript, vitest } from 'eslint-config-uphold';
 ```
 
 > [!NOTE]

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -7,8 +7,9 @@
     "moduleResolution": "nodenext",
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
-    "skipLibCheck": false,
-    "strict": true
+    "skipLibCheck": true,
+    "strict": true,
+    "types": ["node"]
   },
   "exclude": ["node_modules"],
   "typeAcquisition": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
   "author": "Uphold",
   "main": "./src/index.js",
   "exports": {
-    ".": "./src/index.js",
-    "./configs": "./src/configs/index.js"
+    ".": "./src/index.js"
   },
   "repository": {
     "type": "git",

--- a/src/configs/common.js
+++ b/src/configs/common.js
@@ -387,6 +387,19 @@ export const upholdScriptsBinConfig = {
   name: 'uphold/scripts-bin',
   rules: {
     'n/no-process-exit': 'off',
+    'n/no-sync': 'off',
     'no-console': 'off'
+  }
+};
+
+/**
+ * Configuration for `config` files.
+ * @type {import('eslint').Linter.Config}
+ */
+export const upholdConfigFilesConfig = {
+  files: ['**/config/**'],
+  name: 'uphold/config-files',
+  rules: {
+    'n/no-sync': 'off'
   }
 };

--- a/src/configs/index.js
+++ b/src/configs/index.js
@@ -3,30 +3,23 @@
  */
 
 import { createJavaScriptConfig } from './javascript.js';
+import { createJestConfig } from './jest.js';
+import { createMochaConfig } from './mocha.js';
 import { createTypeScriptConfig } from './typescript.js';
-import { defineConfig } from 'eslint/config';
-import jestConfig from './jest.js';
-import mochaConfig from './mocha.js';
-import vitestConfig from './vitest.js';
+import { createVitestConfig } from './vitest.js';
 
 /**
  * Export the Configurations.
  */
 
 export const javascript = createJavaScriptConfig('commonjs');
-export const jest = defineConfig(jestConfig);
-export const mocha = defineConfig(mochaConfig);
+export const jest = await createJestConfig();
+export const mocha = await createMochaConfig();
 export const typescript = await createTypeScriptConfig('module');
-export const vitest = defineConfig(vitestConfig);
+export const vitest = await createVitestConfig();
 
 /**
  * Export configuration factories.
  */
 
 export { createJavaScriptConfig, createTypeScriptConfig };
-
-/**
- * Default export.
- */
-
-export default { createJavaScriptConfig, createTypeScriptConfig, javascript, jest, mocha, typescript, vitest };

--- a/src/configs/javascript.js
+++ b/src/configs/javascript.js
@@ -13,6 +13,7 @@ import {
   sortKeysFixConfig,
   sqlTemplateConfig,
   stylisticConfig,
+  upholdConfigFilesConfig,
   upholdPluginConfig,
   upholdScriptsBinConfig
 } from './common.js';
@@ -63,6 +64,7 @@ export function createJavaScriptConfig(moduleType = 'commonjs', { ecmaVersion = 
     sqlTemplateConfig,
     stylisticConfig,
     upholdPluginConfig,
+    upholdConfigFilesConfig,
     upholdScriptsBinConfig,
     // Prettier must be the last config to disable conflicting rules.
     eslintPluginPrettierRecommended,

--- a/src/configs/javascript.js
+++ b/src/configs/javascript.js
@@ -65,6 +65,13 @@ export function createJavaScriptConfig(moduleType = 'commonjs', { ecmaVersion = 
     upholdPluginConfig,
     upholdScriptsBinConfig,
     // Prettier must be the last config to disable conflicting rules.
-    eslintPluginPrettierRecommended
+    eslintPluginPrettierRecommended,
+    // Overrides for Prettier to re-enable `curly`, which is disabled by Prettier's recommended config.
+    {
+      name: 'uphold/prettier-overrides',
+      rules: {
+        curly: 'error'
+      }
+    }
   ]);
 }

--- a/src/configs/javascript.js
+++ b/src/configs/javascript.js
@@ -42,7 +42,6 @@ export function createJavaScriptConfig(moduleType = 'commonjs', { ecmaVersion = 
   return defineConfig([
     {
       extends: [js.configs.recommended],
-      files: ['**/*.{js,cjs,mjs,jsx}'],
       languageOptions: {
         ecmaVersion,
         globals: nodeGlobals,

--- a/src/configs/jest.js
+++ b/src/configs/jest.js
@@ -47,7 +47,10 @@ export async function createJestConfig(utils) {
   }
 
   if (isJestAvailable) {
-    console.warn('`eslint-plugin-jest` is not installed, Jest linting will be disabled');
+    process.emitWarning('`eslint-plugin-jest` is not installed, Jest linting will be disabled', {
+      code: 'UPHOLD_ESLINT_JEST_PLUGIN_MISSING',
+      type: 'UpholdEslintWarning'
+    });
 
     return defineConfig({
       languageOptions: {

--- a/src/configs/jest.js
+++ b/src/configs/jest.js
@@ -2,6 +2,7 @@
  * Module dependencies.
  */
 
+import { defineConfig } from 'eslint/config';
 import { isModuleAvailable, loadModule } from '../utils/load-module.js';
 import globals from 'globals';
 
@@ -14,7 +15,7 @@ import globals from 'globals';
 /**
  * Create Jest ESLint config.
  * @param {LoaderUtils} [utils] - Optional utilities for dependency injection (for testing).
- * @returns {Promise<import('@eslint/config-helpers').ConfigWithExtends>} The Jest ESLint config.
+ * @returns {Promise<import('eslint').Linter.Config[]>} The Jest ESLint config.
  */
 export async function createJestConfig(utils) {
   const checkModule = utils?.isModuleAvailable ?? isModuleAvailable;
@@ -28,9 +29,9 @@ export async function createJestConfig(utils) {
       /** @type {{ configs: Record<string, import('@eslint/config-helpers').Config> }} */
       (await loadMod('eslint-plugin-jest'));
 
-    return {
+    return defineConfig({
       extends: [{ ...jestPlugin.configs['flat/recommended'], name: 'jest/recommended' }],
-      name: 'uphold/jest-plugin-config',
+      name: 'uphold/jest',
       rules: {
         'jest/padding-around-describe-blocks': 'warn',
         'jest/padding-around-expect-groups': 'warn',
@@ -42,28 +43,22 @@ export async function createJestConfig(utils) {
         'jest/prefer-to-have-length': 'warn',
         'jest/prefer-todo': 'warn'
       }
-    };
+    });
   }
 
   if (isJestAvailable) {
     console.warn('`eslint-plugin-jest` is not installed, Jest linting will be disabled');
 
-    return {
+    return defineConfig({
       languageOptions: {
         globals: globals.jest
       },
-      name: 'uphold/jest-globals'
-    };
+      name: 'uphold/jest'
+    });
   }
 
   // Jest not installed, exporting an empty config.
-  return {
-    name: 'uphold/jest-empty'
-  };
+  return defineConfig({
+    name: 'uphold/jest'
+  });
 }
-
-/**
- * Export the default configuration (evaluated at module load time).
- */
-
-export default await createJestConfig();

--- a/src/configs/mocha.js
+++ b/src/configs/mocha.js
@@ -42,7 +42,10 @@ export async function createMochaConfig(utils) {
   }
 
   if (isMochaAvailable) {
-    console.warn('`eslint-plugin-mocha` is not installed, Mocha linting will be disabled');
+    process.emitWarning('`eslint-plugin-mocha` is not installed, Mocha linting will be disabled', {
+      code: 'UPHOLD_ESLINT_MOCHA_PLUGIN_MISSING',
+      type: 'UpholdEslintWarning'
+    });
 
     return defineConfig({
       languageOptions: {

--- a/src/configs/mocha.js
+++ b/src/configs/mocha.js
@@ -2,6 +2,7 @@
  * Module dependencies.
  */
 
+import { defineConfig } from 'eslint/config';
 import { isModuleAvailable, loadModule } from '../utils/load-module.js';
 import globals from 'globals';
 
@@ -14,7 +15,7 @@ import globals from 'globals';
 /**
  * Create Mocha ESLint config.
  * @param {LoaderUtils} [utils] - Optional utilities for dependency injection (for testing).
- * @returns {Promise<import('@eslint/config-helpers').ConfigWithExtends>} The Mocha ESLint config.
+ * @returns {Promise<import('eslint').Linter.Config[]>} The Mocha ESLint config.
  */
 export async function createMochaConfig(utils) {
   const checkModule = utils?.isModuleAvailable ?? isModuleAvailable;
@@ -28,37 +29,31 @@ export async function createMochaConfig(utils) {
       /** @type {{ configs: { recommended: import('@eslint/config-helpers').Config } }} */
       (await loadMod('eslint-plugin-mocha'));
 
-    return {
+    return defineConfig({
       extends: [pluginMocha.configs.recommended],
-      name: 'uphold/mocha-plugin-config',
+      name: 'uphold/mocha',
       rules: {
         'mocha/no-exclusive-tests': 'error',
         'mocha/no-identical-title': 'error',
         'mocha/no-nested-tests': 'error',
         'mocha/no-sibling-hooks': 'error'
       }
-    };
+    });
   }
 
   if (isMochaAvailable) {
     console.warn('`eslint-plugin-mocha` is not installed, Mocha linting will be disabled');
 
-    return {
+    return defineConfig({
       languageOptions: {
         globals: globals.mocha
       },
-      name: 'uphold/mocha-globals'
-    };
+      name: 'uphold/mocha'
+    });
   }
 
   // Mocha not installed, exporting an empty config.
-  return {
-    name: 'uphold/mocha-empty'
-  };
+  return defineConfig({
+    name: 'uphold/mocha'
+  });
 }
-
-/**
- * Export the default configuration (evaluated at module load time).
- */
-
-export default await createMochaConfig();

--- a/src/configs/typescript.js
+++ b/src/configs/typescript.js
@@ -13,6 +13,7 @@ import {
   sortKeysFixConfig,
   sqlTemplateConfig,
   stylisticConfig,
+  upholdConfigFilesConfig,
   upholdPluginConfig,
   upholdScriptsBinConfig
 } from './common.js';
@@ -42,6 +43,7 @@ const commonConfigs = [
   sqlTemplateConfig,
   stylisticConfig,
   upholdPluginConfig,
+  upholdConfigFilesConfig,
   upholdScriptsBinConfig,
   // Prettier must be the last config to disable conflicting rules.
   eslintPluginPrettierRecommended

--- a/src/configs/typescript.js
+++ b/src/configs/typescript.js
@@ -71,7 +71,6 @@ const buildFallbackConfig = ({
   return defineConfig([
     {
       extends: [js.configs.recommended],
-      files: ['**/*.cts', '**/*.d.ts', '**/*.mts', '**/*.ts', '**/*.tsx'],
       languageOptions: {
         ecmaVersion,
         globals: nodeGlobals,
@@ -112,7 +111,6 @@ export async function createTypeScriptConfig(moduleType = 'module', { ecmaVersio
     return defineConfig([
       {
         extends: [js.configs.recommended, tseslint.configs.recommended],
-        files: ['**/*.cts', '**/*.d.ts', '**/*.mts', '**/*.ts', '**/*.tsx'],
         languageOptions: {
           ecmaVersion,
           globals: nodeGlobals,

--- a/src/configs/typescript.js
+++ b/src/configs/typescript.js
@@ -135,7 +135,10 @@ export async function createTypeScriptConfig(moduleType = 'module', { ecmaVersio
     ]);
   }
 
-  console.warn('`typescript-eslint` not installed. Falling back to ESLint for TypeScript linting');
+  process.emitWarning('`typescript-eslint` not installed. Falling back to ESLint for TypeScript linting', {
+    code: 'UPHOLD_ESLINT_TYPESCRIPT_ESLINT_MISSING',
+    type: 'UpholdEslintWarning'
+  });
 
   return buildFallbackConfig({ ecmaVersion, moduleType, nodeGlobals });
 }

--- a/src/configs/vitest.js
+++ b/src/configs/vitest.js
@@ -2,6 +2,7 @@
  * Module dependencies.
  */
 
+import { defineConfig } from 'eslint/config';
 import { isModuleAvailable, loadModule } from '../utils/load-module.js';
 import globals from 'globals';
 
@@ -14,7 +15,7 @@ import globals from 'globals';
 /**
  * Create Vitest ESLint config.
  * @param {LoaderUtils} [utils] - Optional utilities for dependency injection (for testing).
- * @returns {Promise<import('@eslint/config-helpers').ConfigWithExtends>} The Vitest ESLint config.
+ * @returns {Promise<import('eslint').Linter.Config[]>} The Vitest ESLint config.
  */
 export async function createVitestConfig(utils) {
   const checkModule = utils?.isModuleAvailable ?? isModuleAvailable;
@@ -26,10 +27,10 @@ export async function createVitestConfig(utils) {
   if (isVitestPluginAvailable && isVitestAvailable) {
     const vitestPlugin = await loadMod('@vitest/eslint-plugin');
 
-    return {
+    return defineConfig({
       extends: [vitestPlugin.configs.recommended],
       languageOptions: vitestPlugin.configs.env.languageOptions,
-      name: 'uphold/vitest-plugin-config',
+      name: 'uphold/vitest',
       rules: {
         'vitest/no-commented-out-tests': 'warn',
         'vitest/no-disabled-tests': 'warn',
@@ -41,28 +42,22 @@ export async function createVitestConfig(utils) {
         'vitest/prefer-expect-resolves': 'warn',
         'vitest/prefer-to-have-length': 'warn'
       }
-    };
+    });
   }
 
   if (isVitestAvailable) {
     console.warn('`@vitest/eslint-plugin` is not installed, Vitest linting will be disabled');
 
-    return {
+    return defineConfig({
       languageOptions: {
         globals: globals.vitest
       },
-      name: 'uphold/vitest-globals'
-    };
+      name: 'uphold/vitest'
+    });
   }
 
   // Vitest not installed, exporting an empty config.
-  return {
-    name: 'uphold/vitest-empty'
-  };
+  return defineConfig({
+    name: 'uphold/vitest'
+  });
 }
-
-/**
- * Export the default configuration (evaluated at module load time).
- */
-
-export default await createVitestConfig();

--- a/src/configs/vitest.js
+++ b/src/configs/vitest.js
@@ -25,7 +25,10 @@ export async function createVitestConfig(utils) {
   const isVitestAvailable = checkModule('vitest');
 
   if (isVitestPluginAvailable && isVitestAvailable) {
-    const vitestPlugin = await loadMod('@vitest/eslint-plugin');
+    /** @type {{ configs: { recommended: import('eslint').Linter.Config, env: { languageOptions: import('eslint').Linter.LanguageOptions } } }} */
+    const vitestPlugin =
+      /** @type {never} */
+      (await loadMod('@vitest/eslint-plugin'));
 
     return defineConfig({
       extends: [vitestPlugin.configs.recommended],
@@ -46,7 +49,10 @@ export async function createVitestConfig(utils) {
   }
 
   if (isVitestAvailable) {
-    console.warn('`@vitest/eslint-plugin` is not installed, Vitest linting will be disabled');
+    process.emitWarning('`@vitest/eslint-plugin` is not installed, Vitest linting will be disabled', {
+      code: 'UPHOLD_ESLINT_VITEST_PLUGIN_MISSING',
+      type: 'UpholdEslintWarning'
+    });
 
     return defineConfig({
       languageOptions: {

--- a/src/index.js
+++ b/src/index.js
@@ -112,10 +112,21 @@ const uphold = defineConfig([
 ]);
 
 /**
- * Export the configuration.
- *
- * @see https://nodejs.org/docs/latest-v22.x/api/modules.html#loading-ecmascript-modules-using-require
+ * Re-export all configs from src/configs/index.js.
  */
 
-export { uphold as 'module.exports' };
+export {
+  createJavaScriptConfig,
+  createTypeScriptConfig,
+  javascript,
+  jest,
+  mocha,
+  typescript,
+  vitest
+} from './configs/index.js';
+
+/**
+ * Export the default configuration.
+ */
+
 export default uphold;

--- a/src/index.js
+++ b/src/index.js
@@ -2,112 +2,20 @@
  * Module dependencies.
  */
 
+import { createJavaScriptConfig } from './configs/javascript.js';
 import { defineConfig } from 'eslint/config';
-import {
-  eslintRules,
-  jsdocPluginConfigJavaScript,
-  nodePluginConfig,
-  promisePluginConfig,
-  sortDestructureKeysConfig,
-  sortImportsRequiresConfig,
-  sortKeysFixConfig,
-  sqlTemplateConfig,
-  stylisticConfig
-} from './configs/common.js';
-import { fixupPluginRules } from '@eslint/compat';
-import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
-import globals from 'globals';
-import js from '@eslint/js';
-import jsdoc from 'eslint-plugin-jsdoc';
-import mocha from 'eslint-plugin-mocha';
-import nodePlugin from 'eslint-plugin-n';
-import promise from 'eslint-plugin-promise';
-import rules from './rules/index.js';
-import sortDestructureKeys from 'eslint-plugin-sort-destructure-keys';
-import sortImportsRequires from 'eslint-plugin-sort-imports-requires';
-import sortKeysFix from 'eslint-plugin-sort-keys-fix';
-import sqlTemplate from 'eslint-plugin-sql-template';
-import stylistic from '@stylistic/eslint-plugin';
 
 /**
- * Language options.
- *
- * @type {import('eslint').Linter.Config['languageOptions']}
- */
-
-const languageOptions = {
-  ecmaVersion: 2024,
-  globals: globals.node,
-  sourceType: 'module'
-};
-
-/**
- * Base configuration for Uphold.
- *
+ * Default Uphold ESLint configuration preset.
+ * - Uses CommonJS with ECMAScript 2024 by default.
  * @type {import('eslint').Linter.Config[]}
  */
-
-const upholdBaseConfig = defineConfig([
+export default defineConfig([
+  createJavaScriptConfig('commonjs', { ecmaVersion: 2024 }),
   {
-    extends: [js.configs.recommended, jsdocPluginConfigJavaScript, eslintPluginPrettierRecommended],
-    languageOptions,
-    name: 'uphold/base',
-    plugins: {
-      '@stylistic': stylistic,
-      jsdoc,
-      mocha,
-      // eslint-disable-next-line id-length
-      n: nodePlugin,
-      // @ts-expect-error Outdated types for `eslint-plugin-promise`.
-      promise,
-      'sort-destructure-keys': sortDestructureKeys,
-      'sort-imports-requires': sortImportsRequires,
-      'sort-keys-fix': fixupPluginRules(sortKeysFix),
-      'sql-template': sqlTemplate,
-      'uphold-plugin': { rules }
-    },
     rules: {
-      ...eslintRules,
-      ...nodePluginConfig.rules,
-      ...promisePluginConfig.rules,
-      ...sortDestructureKeysConfig.rules,
-      ...sortImportsRequiresConfig.rules,
-      ...sortKeysFixConfig.rules,
-      ...sqlTemplateConfig.rules,
-      ...stylisticConfig.rules,
-      'uphold-plugin/explicit-sinon-use-fake-timers': 'error',
-      'uphold-plugin/no-trailing-period-in-log-messages': 'error',
-      'uphold-plugin/require-comment-punctuation': 'error'
+      'uphold-plugin/explicit-sinon-use-fake-timers': 'error'
     }
-  }
-]);
-
-/**
- * Configuration for bin and scripts files.
- *
- * @type {import('eslint').Linter.Config}
- */
-
-const upholdBinScriptsConfig = {
-  files: ['**/bin/**', '**/scripts/**'],
-  languageOptions,
-  name: 'uphold/scripts',
-  rules: {
-    'n/no-process-exit': 'off',
-    'no-console': 'off'
-  }
-};
-
-/**
- * `uphold` shared configuration preset.
- *
- * @type {import('eslint').Linter.Config[]}
- */
-
-const uphold = defineConfig([
-  {
-    extends: [upholdBaseConfig, upholdBinScriptsConfig],
-    name: 'uphold/default'
   }
 ]);
 
@@ -124,9 +32,3 @@ export {
   typescript,
   vitest
 } from './configs/index.js';
-
-/**
- * Export the default configuration.
- */
-
-export default uphold;

--- a/src/utils/load-module.js
+++ b/src/utils/load-module.js
@@ -17,7 +17,7 @@ function isModuleAvailable(moduleName) {
 
     return true;
   } catch (error) {
-    if (error?.code === 'MODULE_NOT_FOUND') {
+    if (error instanceof Error && 'code' in error && error.code === 'MODULE_NOT_FOUND') {
       return false;
     }
 
@@ -32,11 +32,9 @@ function isModuleAvailable(moduleName) {
  *  "@vitest/eslint-plugin": import('@vitest/eslint-plugin'),
  *  "eslint-plugin-jest": import('eslint-plugin-jest'),
  *  "eslint-plugin-mocha": import('eslint-plugin-mocha'),
- *  "jest": import('jest'),
- *  "mocha": import('mocha'),
+ *  "globals": import('globals'),
  *  "typescript": import('typescript'),
- *  "typescript-eslint": import('typescript-eslint'),
- *  "vitest": import('vitest')
+ *  "typescript-eslint": import('typescript-eslint')
  * }} ModuleMap
  */
 

--- a/test/fixtures/bin/correct.js
+++ b/test/fixtures/bin/correct.js
@@ -1,5 +1,10 @@
+const fs = require('node:fs');
+
 // `no-console`.
 console.log('foo');
+
+// no-sync.
+fs.writeFileSync('foo.txt', 'Hello, world!');
 
 // `no-process-exit`.
 process.exit(0);

--- a/test/fixtures/config/correct.js
+++ b/test/fixtures/config/correct.js
@@ -1,0 +1,4 @@
+const fs = require('node:fs');
+
+// no-sync.
+fs.readFileSync('foo.txt');

--- a/test/fixtures/scripts/correct.js
+++ b/test/fixtures/scripts/correct.js
@@ -1,5 +1,10 @@
+const fs = require('node:fs');
+
 // `no-console`.
 console.log('foo');
+
+// no-sync.
+fs.writeFileSync('foo.txt', 'Hello, world!');
 
 // `no-process-exit`.
 process.exit(0);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -93,6 +93,13 @@ describe('eslint-config-uphold', () => {
     ]);
   });
 
+  it('should not generate any violation for correct code inside config folders', async () => {
+    const source = join(dirname, 'fixtures', 'config', 'correct.js');
+    const [result] = await linter.lintFiles([source]);
+
+    assert.equal(result.messages.length, 0);
+  });
+
   it('should not generate any violation for correct code inside bin & scripts folders', async () => {
     const source1 = join(dirname, 'fixtures', 'bin', 'correct.js');
     const source2 = join(dirname, 'fixtures', 'scripts', 'correct.js');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -101,4 +101,30 @@ describe('eslint-config-uphold', () => {
     assert.equal(result1.messages.length, 0);
     assert.equal(result2.messages.length, 0);
   });
+
+  it('should re-export configs from eslint-config-uphold/configs', async () => {
+    const rootExports = await import('../src/index.js');
+
+    // Verify all configs are re-exported at root level.
+    assert.ok(rootExports.javascript, 'javascript config should be exported');
+    assert.ok(rootExports.jest, 'jest config should be exported');
+    assert.ok(rootExports.mocha, 'mocha config should be exported');
+    assert.ok(rootExports.typescript, 'typescript config should be exported');
+    assert.ok(rootExports.vitest, 'vitest config should be exported');
+
+    // Verify factory functions are re-exported.
+    assert.strictEqual(
+      typeof rootExports.createJavaScriptConfig,
+      'function',
+      'createJavaScriptConfig should be exported'
+    );
+    assert.strictEqual(
+      typeof rootExports.createTypeScriptConfig,
+      'function',
+      'createTypeScriptConfig should be exported'
+    );
+
+    // Verify default export is still the uphold config array.
+    assert.ok(Array.isArray(rootExports.default), 'default export should be an array');
+  });
 });

--- a/test/src/configs/index.test.js
+++ b/test/src/configs/index.test.js
@@ -30,7 +30,14 @@ describe('Test configs', () => {
   for (const configName of ['javascript', 'jest', 'mocha', 'typescript', 'vitest']) {
     it(`should export \`${configName}\` config with correct structure`, async () => {
       const configs = await import('../../../src/configs/index.js');
-      const config = configs[configName];
+      const config =
+        /** @type {import('eslint').Linter.Config[]} */
+        (
+          configs[
+            /** @type {keyof typeof configs} */
+            (configName)
+          ]
+        );
 
       assert.ok(Array.isArray(config), `\`${configName}\` config should be an array`);
       assert.ok(config.length > 0, `\`${configName}\` config array should not be empty`);

--- a/test/src/configs/index.test.js
+++ b/test/src/configs/index.test.js
@@ -13,7 +13,6 @@ describe('Test configs', () => {
   it('should export all configs', async () => {
     const configs = await import('../../../src/configs/index.js');
 
-    assert.ok(configs.default, '`default export` should exist');
     assert.ok(configs.javascript, '`javascript` config should be exported');
     assert.ok(configs.jest, '`jest` config should be exported');
     assert.ok(configs.mocha, '`mocha` config should be exported');
@@ -21,14 +20,11 @@ describe('Test configs', () => {
     assert.ok(configs.vitest, '`vitest` config should be exported');
   });
 
-  it('should support default import', async () => {
+  it('should export factory functions', async () => {
     const configs = await import('../../../src/configs/index.js');
 
-    assert.ok(configs.default.javascript, '`default export` should have `javascript`');
-    assert.ok(configs.default.jest, '`default export` should have `jest`');
-    assert.ok(configs.default.mocha, '`default export` should have `mocha`');
-    assert.ok(configs.default.typescript, '`default export` should have `typescript`');
-    assert.ok(configs.default.vitest, '`default export` should have `vitest`');
+    assert.strictEqual(typeof configs.createJavaScriptConfig, 'function', 'createJavaScriptConfig should be exported');
+    assert.strictEqual(typeof configs.createTypeScriptConfig, 'function', 'createTypeScriptConfig should be exported');
   });
 
   for (const configName of ['javascript', 'jest', 'mocha', 'typescript', 'vitest']) {

--- a/test/src/configs/javascript.test.js
+++ b/test/src/configs/javascript.test.js
@@ -101,8 +101,8 @@ describe('JavaScript config', () => {
     it('should include all common configs', () => {
       const config = createJavaScriptConfig();
 
-      // Main config + 12 common configs + 1 from extends flattening = 14.
-      assert.strictEqual(config.length, 14, 'Should have 14 configs total after `defineConfig` flattening');
+      // Main config + 13 common configs + 1 from extends flattening = 15.
+      assert.strictEqual(config.length, 15, 'Should have 15 configs total after `defineConfig` flattening');
     });
 
     it('should have ESLint rules configured', () => {

--- a/test/src/configs/javascript.test.js
+++ b/test/src/configs/javascript.test.js
@@ -101,8 +101,8 @@ describe('JavaScript config', () => {
     it('should include all common configs', () => {
       const config = createJavaScriptConfig();
 
-      // Main config + 11 common configs + 1 from extends flattening = 13.
-      assert.strictEqual(config.length, 13, 'Should have 13 configs total after `defineConfig` flattening');
+      // Main config + 12 common configs + 1 from extends flattening = 14.
+      assert.strictEqual(config.length, 14, 'Should have 14 configs total after `defineConfig` flattening');
     });
 
     it('should have ESLint rules configured', () => {

--- a/test/src/configs/jest.test.js
+++ b/test/src/configs/jest.test.js
@@ -11,54 +11,32 @@ import assert from 'node:assert/strict';
  */
 
 describe('Jest config', () => {
-  describe('default export', () => {
-    it('should export a valid ESLint config object', async () => {
-      const jestConfig = await import('../../../src/configs/jest.js');
-
-      assert.ok(jestConfig.default, 'Should have default export');
-      assert.ok(jestConfig.default.name, 'Config should have a name');
-      assert.ok(typeof jestConfig.default === 'object', 'Config should be an object');
-    });
-
-    it('should have correct name prefix', async () => {
-      const jestConfig = await import('../../../src/configs/jest.js');
-
-      assert.ok(jestConfig.default.name, 'Config should have a name');
-      assert.ok(
-        jestConfig.default.name.startsWith('uphold/jest'),
-        `Config name should start with 'uphold/jest', got: ${jestConfig.default.name}`
-      );
-    });
-  });
-
   describe('createJestConfig()', () => {
-    it('should export an empty config when Jest is not installed', async () => {
-      const config = await createJestConfig({
+    it('should return a config array when Jest is not installed', async () => {
+      const configs = await createJestConfig({
         isModuleAvailable: () => false,
         loadModule: () => Promise.resolve({})
       });
 
-      assert.strictEqual(config.name, 'uphold/jest-empty', 'Should have empty config name');
-      assert.ok(!config.extends, 'Empty config should not have extends');
-      assert.ok(!config.rules, 'Empty config should not have rules');
-      assert.ok(!config.languageOptions, 'Empty config should not have `languageOptions`');
+      assert.ok(Array.isArray(configs), 'Should return an array');
+      assert.strictEqual(configs.length, 1, 'Should have one config');
+      assert.strictEqual(configs[0].name, 'uphold/jest', 'Should have correct config name');
+      assert.ok(!configs[0].rules, 'Empty config should not have rules');
+      assert.ok(!configs[0].languageOptions, 'Empty config should not have `languageOptions`');
     });
 
-    it('should export globals config when Jest is installed but plugin is not', async context => {
+    it('should return globals config when Jest is installed but plugin is not', async context => {
       const warnMock = context.mock.method(console, 'warn');
-      const config = await createJestConfig({
+      const configs = await createJestConfig({
         isModuleAvailable: moduleName => moduleName === 'jest'
       });
 
-      assert.strictEqual(
-        config.name,
-        'uphold/jest-globals',
-        'Should have globals config name when plugin not installed'
-      );
-      assert.ok(config.languageOptions, 'Should have `languageOptions`');
-      assert.ok(config.languageOptions.globals, 'Should have Jest globals defined');
-      assert.ok(!config.extends, 'Globals config should not have extends');
-      assert.ok(!config.rules, 'Globals config should not have rules');
+      assert.ok(Array.isArray(configs), 'Should return an array');
+      assert.strictEqual(configs.length, 1, 'Should have one config');
+      assert.strictEqual(configs[0].name, 'uphold/jest', 'Should have correct config name');
+      assert.ok(configs[0].languageOptions, 'Should have `languageOptions`');
+      assert.ok(configs[0].languageOptions.globals, 'Should have Jest globals defined');
+      assert.ok(!configs[0].rules, 'Globals config should not have rules');
 
       // Verify warning was logged.
       assert.strictEqual(warnMock.mock.callCount(), 1, 'Should have logged a warning');
@@ -68,10 +46,10 @@ describe('Jest config', () => {
       );
     });
 
-    it('should export full plugin config when both Jest and plugin are installed', async () => {
-      const mockRecommendedConfig = { rules: { 'jest/no-disabled-tests': 'warn' } };
+    it('should return full plugin config when both Jest and plugin are installed', async () => {
+      const mockRecommendedConfig = { name: 'jest/recommended', rules: { 'jest/no-disabled-tests': 'warn' } };
 
-      const config = await createJestConfig({
+      const configs = await createJestConfig({
         isModuleAvailable: moduleName => moduleName === 'jest' || moduleName === 'eslint-plugin-jest',
         loadModule: moduleName => {
           if (moduleName === 'eslint-plugin-jest') {
@@ -82,25 +60,32 @@ describe('Jest config', () => {
         }
       });
 
-      assert.strictEqual(config.name, 'uphold/jest-plugin-config', 'Should have plugin config name');
-      assert.ok(config.extends, 'Should have extends');
-      assert.ok(Array.isArray(config.extends), 'extends should be an array');
-      assert.strictEqual(config.extends.length, 1, 'extends should have one config');
-      // @ts-expect-error Incomplete typing for extends.
-      assert.strictEqual(config.extends[0].name, 'jest/recommended', 'Extended config should have correct name');
-      assert.ok(config.rules, 'Should have rules');
-      assert.equal(Object.keys(config.rules).length, 9);
-      assert.strictEqual(config.rules['jest/padding-around-describe-blocks'], 'warn');
-      assert.strictEqual(config.rules['jest/padding-around-expect-groups'], 'warn');
-      assert.strictEqual(config.rules['jest/prefer-equality-matcher'], 'warn');
-      assert.strictEqual(config.rules['jest/prefer-to-be'], 'warn');
-      assert.strictEqual(config.rules['jest/prefer-to-contain'], 'warn');
-      assert.strictEqual(config.rules['jest/prefer-to-have-been-called'], 'warn');
-      assert.strictEqual(config.rules['jest/prefer-to-have-been-called-times'], 'warn');
-      assert.strictEqual(config.rules['jest/prefer-to-have-length'], 'warn');
-      assert.strictEqual(config.rules['jest/prefer-todo'], 'warn');
+      assert.ok(Array.isArray(configs), 'Should return an array');
+      // defineConfig flattens extends, so we have 2 configs: jest/recommended + uphold/jest.
+      assert.strictEqual(configs.length, 2, 'Should have two configs (extended + main)');
 
-      assert.ok(!config.languageOptions, 'Plugin config should not have `languageOptions`');
+      // First config is the extended jest/recommended (prefixed by defineConfig).
+      assert.strictEqual(
+        configs[0].name,
+        'uphold/jest > jest/recommended',
+        'First config should be prefixed jest/recommended'
+      );
+
+      // Second config is our uphold/jest config with rules.
+      assert.strictEqual(configs[1].name, 'uphold/jest', 'Second config should be uphold/jest');
+      assert.ok(configs[1].rules, 'Should have rules');
+      assert.equal(Object.keys(configs[1].rules).length, 9);
+      assert.strictEqual(configs[1].rules['jest/padding-around-describe-blocks'], 'warn');
+      assert.strictEqual(configs[1].rules['jest/padding-around-expect-groups'], 'warn');
+      assert.strictEqual(configs[1].rules['jest/prefer-equality-matcher'], 'warn');
+      assert.strictEqual(configs[1].rules['jest/prefer-to-be'], 'warn');
+      assert.strictEqual(configs[1].rules['jest/prefer-to-contain'], 'warn');
+      assert.strictEqual(configs[1].rules['jest/prefer-to-have-been-called'], 'warn');
+      assert.strictEqual(configs[1].rules['jest/prefer-to-have-been-called-times'], 'warn');
+      assert.strictEqual(configs[1].rules['jest/prefer-to-have-length'], 'warn');
+      assert.strictEqual(configs[1].rules['jest/prefer-todo'], 'warn');
+
+      assert.ok(!configs[1].languageOptions, 'Plugin config should not have `languageOptions`');
     });
   });
 });

--- a/test/src/configs/jest.test.js
+++ b/test/src/configs/jest.test.js
@@ -26,7 +26,7 @@ describe('Jest config', () => {
     });
 
     it('should return globals config when Jest is installed but plugin is not', async context => {
-      const warnMock = context.mock.method(console, 'warn');
+      const warnMock = context.mock.method(process, 'emitWarning');
       const configs = await createJestConfig({
         isModuleAvailable: moduleName => moduleName === 'jest'
       });
@@ -38,12 +38,16 @@ describe('Jest config', () => {
       assert.ok(configs[0].languageOptions.globals, 'Should have Jest globals defined');
       assert.ok(!configs[0].rules, 'Globals config should not have rules');
 
-      // Verify warning was logged.
-      assert.strictEqual(warnMock.mock.callCount(), 1, 'Should have logged a warning');
+      // Verify warning was emitted.
+      assert.strictEqual(warnMock.mock.callCount(), 1, 'Should have emitted a warning');
       assert.strictEqual(
         warnMock.mock.calls[0].arguments[0],
         '`eslint-plugin-jest` is not installed, Jest linting will be disabled'
       );
+      assert.deepStrictEqual(warnMock.mock.calls[0].arguments[1], {
+        code: 'UPHOLD_ESLINT_JEST_PLUGIN_MISSING',
+        type: 'UpholdEslintWarning'
+      });
     });
 
     it('should return full plugin config when both Jest and plugin are installed', async () => {

--- a/test/src/configs/mocha.test.js
+++ b/test/src/configs/mocha.test.js
@@ -25,7 +25,7 @@ describe('Mocha config', () => {
     });
 
     it('should return globals config when Mocha is installed but plugin is not', async context => {
-      const warnMock = context.mock.method(console, 'warn');
+      const warnMock = context.mock.method(process, 'emitWarning');
       const configs = await createMochaConfig({
         isModuleAvailable: moduleName => moduleName === 'mocha'
       });
@@ -37,12 +37,16 @@ describe('Mocha config', () => {
       assert.ok(configs[0].languageOptions.globals, 'Should have Mocha globals defined');
       assert.ok(!configs[0].rules, 'Globals config should not have rules');
 
-      // Verify warning was logged.
-      assert.strictEqual(warnMock.mock.callCount(), 1, 'Should have logged a warning');
+      // Verify warning was emitted.
+      assert.strictEqual(warnMock.mock.callCount(), 1, 'Should have emitted a warning');
       assert.strictEqual(
         warnMock.mock.calls[0].arguments[0],
         '`eslint-plugin-mocha` is not installed, Mocha linting will be disabled'
       );
+      assert.deepStrictEqual(warnMock.mock.calls[0].arguments[1], {
+        code: 'UPHOLD_ESLINT_MOCHA_PLUGIN_MISSING',
+        type: 'UpholdEslintWarning'
+      });
     });
 
     it('should return full plugin config when both Mocha and plugin are installed', async () => {

--- a/test/src/configs/mocha.test.js
+++ b/test/src/configs/mocha.test.js
@@ -11,53 +11,31 @@ import assert from 'node:assert';
  */
 
 describe('Mocha config', () => {
-  describe('default export', () => {
-    it('should export a valid ESLint config object', async () => {
-      const mochaConfig = await import('../../../src/configs/mocha.js');
-
-      assert.ok(mochaConfig.default, 'Should have default export');
-      assert.ok(mochaConfig.default.name, 'Config should have a name');
-      assert.ok(typeof mochaConfig.default === 'object', 'Config should be an object');
-    });
-
-    it('should have correct name prefix', async () => {
-      const mochaConfig = await import('../../../src/configs/mocha.js');
-
-      assert.ok(mochaConfig.default.name, 'Config should have a name');
-      assert.ok(
-        mochaConfig.default.name.startsWith('uphold/mocha'),
-        `Config name should start with 'uphold/mocha', got: ${mochaConfig.default.name}`
-      );
-    });
-  });
-
   describe('createMochaConfig()', () => {
-    it('should export an empty config when Mocha is not installed', async () => {
-      const config = await createMochaConfig({
+    it('should return a config array when Mocha is not installed', async () => {
+      const configs = await createMochaConfig({
         isModuleAvailable: () => false
       });
 
-      assert.strictEqual(config.name, 'uphold/mocha-empty', 'Should have empty config name');
-      assert.ok(!config.extends, 'Empty config should not have extends');
-      assert.ok(!config.rules, 'Empty config should not have rules');
-      assert.ok(!config.languageOptions, 'Empty config should not have `languageOptions`');
+      assert.ok(Array.isArray(configs), 'Should return an array');
+      assert.strictEqual(configs.length, 1, 'Should have one config');
+      assert.strictEqual(configs[0].name, 'uphold/mocha', 'Should have correct config name');
+      assert.ok(!configs[0].rules, 'Empty config should not have rules');
+      assert.ok(!configs[0].languageOptions, 'Empty config should not have `languageOptions`');
     });
 
-    it('should export globals config when Mocha is installed but plugin is not', async context => {
+    it('should return globals config when Mocha is installed but plugin is not', async context => {
       const warnMock = context.mock.method(console, 'warn');
-      const config = await createMochaConfig({
+      const configs = await createMochaConfig({
         isModuleAvailable: moduleName => moduleName === 'mocha'
       });
 
-      assert.strictEqual(
-        config.name,
-        'uphold/mocha-globals',
-        'Should have globals config name when plugin not installed'
-      );
-      assert.ok(config.languageOptions, 'Should have `languageOptions`');
-      assert.ok(config.languageOptions.globals, 'Should have Mocha globals defined');
-      assert.ok(!config.extends, 'Globals config should not have extends');
-      assert.ok(!config.rules, 'Globals config should not have rules');
+      assert.ok(Array.isArray(configs), 'Should return an array');
+      assert.strictEqual(configs.length, 1, 'Should have one config');
+      assert.strictEqual(configs[0].name, 'uphold/mocha', 'Should have correct config name');
+      assert.ok(configs[0].languageOptions, 'Should have `languageOptions`');
+      assert.ok(configs[0].languageOptions.globals, 'Should have Mocha globals defined');
+      assert.ok(!configs[0].rules, 'Globals config should not have rules');
 
       // Verify warning was logged.
       assert.strictEqual(warnMock.mock.callCount(), 1, 'Should have logged a warning');
@@ -67,10 +45,10 @@ describe('Mocha config', () => {
       );
     });
 
-    it('should export full plugin config when both Mocha and plugin are installed', async () => {
-      const mockRecommendedConfig = { rules: { 'mocha/no-exclusive-tests': 'error' } };
+    it('should return full plugin config when both Mocha and plugin are installed', async () => {
+      const mockRecommendedConfig = { name: 'mocha/recommended', rules: { 'mocha/no-exclusive-tests': 'error' } };
 
-      const config = await createMochaConfig({
+      const configs = await createMochaConfig({
         isModuleAvailable: moduleName => moduleName === 'mocha' || moduleName === 'eslint-plugin-mocha',
         loadModule: moduleName => {
           if (moduleName === 'eslint-plugin-mocha') {
@@ -81,17 +59,26 @@ describe('Mocha config', () => {
         }
       });
 
-      assert.strictEqual(config.name, 'uphold/mocha-plugin-config', 'Should have plugin config name');
-      assert.ok(config.extends, 'Should have extends');
-      assert.ok(Array.isArray(config.extends), 'extends should be an array');
-      assert.strictEqual(config.extends.length, 1, 'extends should have one config');
-      assert.ok(config.rules, 'Should have rules');
-      assert.strictEqual(Object.keys(config.rules).length, 4);
-      assert.strictEqual(config.rules['mocha/no-exclusive-tests'], 'error');
-      assert.strictEqual(config.rules['mocha/no-identical-title'], 'error');
-      assert.strictEqual(config.rules['mocha/no-nested-tests'], 'error');
-      assert.strictEqual(config.rules['mocha/no-sibling-hooks'], 'error');
-      assert.ok(!config.languageOptions, 'Plugin config should not have `languageOptions`');
+      assert.ok(Array.isArray(configs), 'Should return an array');
+      // defineConfig flattens extends, so we have 2 configs: mocha/recommended + uphold/mocha.
+      assert.strictEqual(configs.length, 2, 'Should have two configs (extended + main)');
+
+      // First config is the extended mocha/recommended (prefixed by defineConfig).
+      assert.strictEqual(
+        configs[0].name,
+        'uphold/mocha > mocha/recommended',
+        'First config should be prefixed mocha/recommended'
+      );
+
+      // Second config is our uphold/mocha config with rules.
+      assert.strictEqual(configs[1].name, 'uphold/mocha', 'Second config should be uphold/mocha');
+      assert.ok(configs[1].rules, 'Should have rules');
+      assert.strictEqual(Object.keys(configs[1].rules).length, 4);
+      assert.strictEqual(configs[1].rules['mocha/no-exclusive-tests'], 'error');
+      assert.strictEqual(configs[1].rules['mocha/no-identical-title'], 'error');
+      assert.strictEqual(configs[1].rules['mocha/no-nested-tests'], 'error');
+      assert.strictEqual(configs[1].rules['mocha/no-sibling-hooks'], 'error');
+      assert.ok(!configs[1].languageOptions, 'Plugin config should not have `languageOptions`');
     });
   });
 });

--- a/test/src/configs/typescript.test.js
+++ b/test/src/configs/typescript.test.js
@@ -158,7 +158,7 @@ describe('TypeScript config', () => {
 
     describe('without `typescript-eslint` (fallback mode)', () => {
       it('should return fallback config for `module` when `typescript` is not installed (no warning)', async context => {
-        const warnMock = context.mock.method(console, 'warn');
+        const warnMock = context.mock.method(process, 'emitWarning');
 
         const config = await createTypeScriptConfig('module', {}, { isModuleAvailable: () => false });
 
@@ -184,11 +184,11 @@ describe('TypeScript config', () => {
           !configWithLangOptions.plugins || !configWithLangOptions.plugins['@typescript-eslint'],
           'Should not have `typescript-eslint` plugin'
         );
-        assert.strictEqual(warnMock.mock.callCount(), 0, 'Should not log a warning when `typescript` is missing');
+        assert.strictEqual(warnMock.mock.callCount(), 0, 'Should not emit a warning when `typescript` is missing');
       });
 
       it('should warn and return fallback config when `typescript` is present but `typescript-eslint` is missing', async context => {
-        const warnMock = context.mock.method(console, 'warn');
+        const warnMock = context.mock.method(process, 'emitWarning');
 
         const config = await createTypeScriptConfig(
           'module',
@@ -205,15 +205,19 @@ describe('TypeScript config', () => {
 
         assert.ok(mainConfig, 'Should have fallback module name');
 
-        assert.strictEqual(warnMock.mock.callCount(), 1, 'Should have logged a warning');
+        assert.strictEqual(warnMock.mock.callCount(), 1, 'Should have emitted a warning');
         assert.strictEqual(
           warnMock.mock.calls[0].arguments[0],
           '`typescript-eslint` not installed. Falling back to ESLint for TypeScript linting'
         );
+        assert.deepStrictEqual(warnMock.mock.calls[0].arguments[1], {
+          code: 'UPHOLD_ESLINT_TYPESCRIPT_ESLINT_MISSING',
+          type: 'UpholdEslintWarning'
+        });
       });
 
       it('should return fallback config for `commonjs` type when `typescript-eslint` not available', async context => {
-        const warnMock = context.mock.method(console, 'warn');
+        const warnMock = context.mock.method(process, 'emitWarning');
 
         const config = await createTypeScriptConfig(
           'commonjs',
@@ -236,11 +240,15 @@ describe('TypeScript config', () => {
           globals.node,
           'Should use `globals.node` for CommonJS'
         );
-        assert.strictEqual(warnMock.mock.callCount(), 1, 'Should have logged a warning');
+        assert.strictEqual(warnMock.mock.callCount(), 1, 'Should have emitted a warning');
         assert.strictEqual(
           warnMock.mock.calls[0].arguments[0],
           '`typescript-eslint` not installed. Falling back to ESLint for TypeScript linting'
         );
+        assert.deepStrictEqual(warnMock.mock.calls[0].arguments[1], {
+          code: 'UPHOLD_ESLINT_TYPESCRIPT_ESLINT_MISSING',
+          type: 'UpholdEslintWarning'
+        });
       });
 
       it('should include all common configs in fallback mode', async () => {

--- a/test/src/configs/typescript.test.js
+++ b/test/src/configs/typescript.test.js
@@ -151,8 +151,8 @@ describe('TypeScript config', () => {
           }
         );
 
-        // Main config + 11 common configs + 2 from extends flattening = 14.
-        assert.strictEqual(config.length, 14, 'Should have 14 configs total after `defineConfig` flattening');
+        // Main config + 12 common configs + 2 from extends flattening = 15.
+        assert.strictEqual(config.length, 15, 'Should have 15 configs total after `defineConfig` flattening');
       });
     });
 
@@ -254,8 +254,8 @@ describe('TypeScript config', () => {
       it('should include all common configs in fallback mode', async () => {
         const config = await createTypeScriptConfig('module', {}, { isModuleAvailable: () => false });
 
-        // Main config + 11 common configs + 1 from extends flattening = 13.
-        assert.strictEqual(config.length, 13, 'Should have 13 configs total after `defineConfig` flattening');
+        // Main config + 12 common configs + 1 from extends flattening = 13.
+        assert.strictEqual(config.length, 14, 'Should have 14 configs total after `defineConfig` flattening');
       });
     });
   });

--- a/test/src/configs/typescript.test.js
+++ b/test/src/configs/typescript.test.js
@@ -172,12 +172,6 @@ describe('TypeScript config', () => {
         const configWithLangOptions = config.find(cfg => cfg.languageOptions?.globals);
 
         assert.ok(configWithLangOptions, 'Should have config with `languageOptions`');
-        assert.ok(configWithLangOptions.files, 'Should have files pattern');
-        assert.ok(Array.isArray(configWithLangOptions.files), 'files should be an array');
-        assert.ok(
-          configWithLangOptions.files.includes('**/*.ts') && configWithLangOptions.files.includes('**/*.tsx'),
-          'Should include TypeScript file patterns'
-        );
         assert.strictEqual(
           // @ts-expect-error configWithLangOptions could be undefined from `config.find`.
           configWithLangOptions.languageOptions.globals,

--- a/test/src/configs/vitest.test.js
+++ b/test/src/configs/vitest.test.js
@@ -11,52 +11,31 @@ import assert from 'node:assert';
  */
 
 describe('Vitest config', () => {
-  describe('default export', () => {
-    it('should export a valid ESLint config object', async () => {
-      const vitestConfig = await import('../../../src/configs/vitest.js');
-
-      assert.ok(vitestConfig.default, 'Should have default export');
-      assert.ok(vitestConfig.default.name, 'Config should have a name');
-      assert.ok(typeof vitestConfig.default === 'object', 'Config should be an object');
-    });
-
-    it('should have correct name prefix', async () => {
-      const vitestConfig = await import('../../../src/configs/vitest.js');
-
-      assert.ok(vitestConfig.default.name, 'Config should have a name');
-      assert.ok(
-        vitestConfig.default.name.startsWith('uphold/vitest'),
-        `Config name should start with 'uphold/vitest', got: ${vitestConfig.default.name}`
-      );
-    });
-  });
-
   describe('createVitestConfig()', () => {
-    it('should export an empty config when Vitest is not installed', async () => {
-      const config = await createVitestConfig({
+    it('should return a config array when Vitest is not installed', async () => {
+      const configs = await createVitestConfig({
         isModuleAvailable: () => false
       });
 
-      assert.strictEqual(config.name, 'uphold/vitest-empty', 'Should have empty config name');
-      assert.ok(!config.languageOptions, 'Empty config should not have `languageOptions`');
-      assert.ok(!config.extends, 'Empty config should not have `extends`');
-      assert.ok(!config.rules, 'Empty config should not have `rules`');
+      assert.ok(Array.isArray(configs), 'Should return an array');
+      assert.strictEqual(configs.length, 1, 'Should have one config');
+      assert.strictEqual(configs[0].name, 'uphold/vitest', 'Should have correct config name');
+      assert.ok(!configs[0].languageOptions, 'Empty config should not have `languageOptions`');
+      assert.ok(!configs[0].rules, 'Empty config should not have `rules`');
     });
 
-    it('should export globals config when Vitest is installed but plugin is not', async context => {
+    it('should return globals config when Vitest is installed but plugin is not', async context => {
       const warnMock = context.mock.method(console, 'warn');
 
-      const config = await createVitestConfig({
+      const configs = await createVitestConfig({
         isModuleAvailable: moduleName => moduleName === 'vitest'
       });
 
-      assert.strictEqual(
-        config.name,
-        'uphold/vitest-globals',
-        'Should have globals config name when plugin not installed'
-      );
-      assert.ok(config.languageOptions, 'Should have `languageOptions`');
-      assert.ok(config.languageOptions.globals, 'Should have Vitest globals defined');
+      assert.ok(Array.isArray(configs), 'Should return an array');
+      assert.strictEqual(configs.length, 1, 'Should have one config');
+      assert.strictEqual(configs[0].name, 'uphold/vitest', 'Should have correct config name');
+      assert.ok(configs[0].languageOptions, 'Should have `languageOptions`');
+      assert.ok(configs[0].languageOptions.globals, 'Should have Vitest globals defined');
 
       // Verify warning was logged.
       assert.strictEqual(warnMock.mock.callCount(), 1, 'Should have logged a warning');
@@ -66,11 +45,11 @@ describe('Vitest config', () => {
       );
     });
 
-    it('should export full plugin config when Vitest and plugin are installed', async () => {
-      const mockRecommendedConfig = { rules: { 'vitest/expect-expect': 'error' } };
+    it('should return full plugin config when Vitest and plugin are installed', async () => {
+      const mockRecommendedConfig = { name: 'vitest/recommended', rules: { 'vitest/expect-expect': 'error' } };
       const mockLanguageOptions = { globals: { vi: true } };
 
-      const config = await createVitestConfig({
+      const configs = await createVitestConfig({
         isModuleAvailable: moduleName => moduleName === 'vitest' || moduleName === '@vitest/eslint-plugin',
         loadModule: moduleName => {
           if (moduleName === '@vitest/eslint-plugin') {
@@ -86,22 +65,31 @@ describe('Vitest config', () => {
         }
       });
 
-      assert.strictEqual(config.name, 'uphold/vitest-plugin-config', 'Should have plugin config name');
-      assert.ok(config.extends, 'Should have `extends`');
-      assert.ok(Array.isArray(config.extends), '`extends` should be an array');
-      assert.strictEqual(config.extends.length, 1, '`extends` should have one config');
-      assert.ok(config.languageOptions, 'Should have `languageOptions`');
-      assert.ok(config.rules, 'Should have `rules`');
-      assert.strictEqual(Object.keys(config.rules).length, 9);
-      assert.strictEqual(config.rules['vitest/no-commented-out-tests'], 'warn');
-      assert.strictEqual(config.rules['vitest/no-disabled-tests'], 'warn');
-      assert.strictEqual(config.rules['vitest/no-focused-tests'], 'error');
-      assert.strictEqual(config.rules['vitest/no-interpolation-in-snapshots'], 'error');
-      assert.strictEqual(config.rules['vitest/no-mocks-import'], 'error');
-      assert.strictEqual(config.rules['vitest/no-standalone-expect'], 'error');
-      assert.strictEqual(config.rules['vitest/no-test-prefixes'], 'error');
-      assert.strictEqual(config.rules['vitest/prefer-expect-resolves'], 'warn');
-      assert.strictEqual(config.rules['vitest/prefer-to-have-length'], 'warn');
+      assert.ok(Array.isArray(configs), 'Should return an array');
+      // defineConfig flattens extends, so we have 2 configs: vitest/recommended + uphold/vitest.
+      assert.strictEqual(configs.length, 2, 'Should have two configs (extended + main)');
+
+      // First config is the extended vitest/recommended (prefixed by defineConfig).
+      assert.strictEqual(
+        configs[0].name,
+        'uphold/vitest > vitest/recommended',
+        'First config should be prefixed vitest/recommended'
+      );
+
+      // Second config is our uphold/vitest config with rules.
+      assert.strictEqual(configs[1].name, 'uphold/vitest', 'Second config should be uphold/vitest');
+      assert.ok(configs[1].languageOptions, 'Should have `languageOptions`');
+      assert.ok(configs[1].rules, 'Should have `rules`');
+      assert.strictEqual(Object.keys(configs[1].rules).length, 9);
+      assert.strictEqual(configs[1].rules['vitest/no-commented-out-tests'], 'warn');
+      assert.strictEqual(configs[1].rules['vitest/no-disabled-tests'], 'warn');
+      assert.strictEqual(configs[1].rules['vitest/no-focused-tests'], 'error');
+      assert.strictEqual(configs[1].rules['vitest/no-interpolation-in-snapshots'], 'error');
+      assert.strictEqual(configs[1].rules['vitest/no-mocks-import'], 'error');
+      assert.strictEqual(configs[1].rules['vitest/no-standalone-expect'], 'error');
+      assert.strictEqual(configs[1].rules['vitest/no-test-prefixes'], 'error');
+      assert.strictEqual(configs[1].rules['vitest/prefer-expect-resolves'], 'warn');
+      assert.strictEqual(configs[1].rules['vitest/prefer-to-have-length'], 'warn');
     });
   });
 });

--- a/test/src/configs/vitest.test.js
+++ b/test/src/configs/vitest.test.js
@@ -25,7 +25,7 @@ describe('Vitest config', () => {
     });
 
     it('should return globals config when Vitest is installed but plugin is not', async context => {
-      const warnMock = context.mock.method(console, 'warn');
+      const warnMock = context.mock.method(process, 'emitWarning');
 
       const configs = await createVitestConfig({
         isModuleAvailable: moduleName => moduleName === 'vitest'
@@ -37,12 +37,16 @@ describe('Vitest config', () => {
       assert.ok(configs[0].languageOptions, 'Should have `languageOptions`');
       assert.ok(configs[0].languageOptions.globals, 'Should have Vitest globals defined');
 
-      // Verify warning was logged.
-      assert.strictEqual(warnMock.mock.callCount(), 1, 'Should have logged a warning');
+      // Verify warning was emitted.
+      assert.strictEqual(warnMock.mock.callCount(), 1, 'Should have emitted a warning');
       assert.strictEqual(
         warnMock.mock.calls[0].arguments[0],
         '`@vitest/eslint-plugin` is not installed, Vitest linting will be disabled'
       );
+      assert.deepStrictEqual(warnMock.mock.calls[0].arguments[1], {
+        code: 'UPHOLD_ESLINT_VITEST_PLUGIN_MISSING',
+        type: 'UpholdEslintWarning'
+      });
     });
 
     it('should return full plugin config when Vitest and plugin are installed', async () => {


### PR DESCRIPTION
## Description

Refactors the project structure ahead of the v7 major release, focusing on simplifying the public API surface and improving the config architecture.

### Unified imports

The `eslint-config-uphold/configs` entry point and the `module.exports` CJS compatibility export are removed. All configs and factory functions are now re-exported directly from `eslint-config-uphold`.

### Configs return arrays

`createJestConfig`, `createMochaConfig`, and `createVitestConfig` now call `defineConfig` internally and return `Linter.Config[]` arrays, matching the JS/TS factories. Config names are standardized to `uphold/jest`, `uphold/mocha`, `uphold/vitest`.

### No default `files` property

The `javascript` and `typescript` configs no longer include a hardcoded `files` glob. Users must specify which files each config applies to.

### Simplified default export

The default export now delegates to `createJavaScriptConfig('commonjs')` instead of duplicating all the plugin setup inline. A `curly: 'error'` Prettier override restores the rule that `eslint-plugin-prettier/recommended` disables.

### `process.emitWarning` for missing optional deps

Replaces `console.warn` calls with `process.emitWarning` using unique codes (e.g. `UPHOLD_ESLINT_JEST_PLUGIN_MISSING`) and type `UpholdEslintWarning`. Warnings are automatically deduplicated by Node.js and can be suppressed with `--no-warnings`.

### Type error fixes

Updated `jsconfig.json` with `"types": ["node"]` and `"skipLibCheck": true`, added JSDoc casts for incomplete plugin types, and used runtime type narrowing for catch blocks.

## Related issues

- N/A

## Steps to reproduce or test

1. Install this branch in a consumer project.
2. Update imports from `eslint-config-uphold/configs` to `eslint-config-uphold`.
3. Adjust the config following migration instructions.
4. Verify linting produces the same results as before.