### PR TITLE
chore: use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/uphold/eslint-config-uphold.git"
+    "url": "git+https://github.com/uphold/eslint-config-uphold.git"
   },
   "files": [
     "src"


### PR DESCRIPTION
## Summary
- update package repository metadata from SSH to `git+https`
- leave runtime code, dependencies, homepage, and bugs metadata unchanged

## Validation
- node metadata assertion
- npm install --ignore-scripts --no-package-lock
- npm run lint
- npm test
- npm pack --dry-run --ignore-scripts --json .
- git diff --check
